### PR TITLE
Adds Ollama support

### DIFF
--- a/.genie/personas/genie-engineer/prompt.yaml
+++ b/.genie/personas/genie-engineer/prompt.yaml
@@ -301,5 +301,7 @@ instruction: |
   {{if .files}}
     {{.files}}
   {{end}}
+llm_provider: ollama
+model_name: gpt-oss:20b
 max_tokens: 15000
 temperature: 0.3

--- a/pkg/genie/wire.go
+++ b/pkg/genie/wire.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kcaldas/genie/pkg/llm/anthropic"
 	"github.com/kcaldas/genie/pkg/llm/genai"
 	"github.com/kcaldas/genie/pkg/llm/multiplexer"
+	"github.com/kcaldas/genie/pkg/llm/ollama"
 	"github.com/kcaldas/genie/pkg/llm/openai"
 	"github.com/kcaldas/genie/pkg/mcp"
 	"github.com/kcaldas/genie/pkg/persona"
@@ -178,6 +179,7 @@ func ProvideAIGenWithCapture(configManager config.Manager) (ai.Gen, error) {
 		"genai":     func() (ai.Gen, error) { return genai.NewClient(eventBus) },
 		"openai":    func() (ai.Gen, error) { return openai.NewClient(eventBus) },
 		"anthropic": func() (ai.Gen, error) { return anthropic.NewClient(eventBus) },
+		"ollama":    func() (ai.Gen, error) { return ollama.NewClient(eventBus) },
 	}
 
 	aliases := map[string]string{

--- a/pkg/genie/wire_gen.go
+++ b/pkg/genie/wire_gen.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kcaldas/genie/pkg/llm/anthropic"
 	"github.com/kcaldas/genie/pkg/llm/genai"
 	"github.com/kcaldas/genie/pkg/llm/multiplexer"
+	"github.com/kcaldas/genie/pkg/llm/ollama"
 	"github.com/kcaldas/genie/pkg/llm/openai"
 	"github.com/kcaldas/genie/pkg/mcp"
 	"github.com/kcaldas/genie/pkg/persona"
@@ -293,6 +294,7 @@ func ProvideAIGenWithCapture(configManager config.Manager) (ai.Gen, error) {
 		"genai":     func() (ai.Gen, error) { return genai.NewClient(eventBus) },
 		"openai":    func() (ai.Gen, error) { return openai.NewClient(eventBus) },
 		"anthropic": func() (ai.Gen, error) { return anthropic.NewClient(eventBus) },
+		"ollama":    func() (ai.Gen, error) { return ollama.NewClient(eventBus) },
 	}
 
 	aliases := map[string]string{

--- a/pkg/llm/ollama/client.go
+++ b/pkg/llm/ollama/client.go
@@ -1,0 +1,559 @@
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kcaldas/genie/pkg/ai"
+	"github.com/kcaldas/genie/pkg/config"
+	"github.com/kcaldas/genie/pkg/events"
+	"github.com/kcaldas/genie/pkg/fileops"
+	"github.com/kcaldas/genie/pkg/logging"
+	"github.com/kcaldas/genie/pkg/template"
+)
+
+const (
+	maxToolIterations = 8
+	defaultBaseURL    = "http://127.0.0.1:11434"
+	chatEndpoint      = "/api/chat"
+	tokenCountPredict = 0
+)
+
+var (
+	errNoBaseURL         = errors.New("ollama base URL not configured")
+	errEmptyResponse     = errors.New("ollama returned an empty response")
+	errToolCallNoHandler = errors.New("model requested tool calls but no handlers were provided")
+
+	_ ai.Gen = (*Client)(nil)
+)
+
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Option configures the Ollama client.
+type Option func(*Client)
+
+// WithConfigManager injects a custom configuration manager.
+func WithConfigManager(manager config.Manager) Option {
+	return func(c *Client) {
+		if manager != nil {
+			c.config = manager
+		}
+	}
+}
+
+// WithFileManager injects a custom file manager (useful for tests).
+func WithFileManager(manager fileops.Manager) Option {
+	return func(c *Client) {
+		if manager != nil {
+			c.fileManager = manager
+		}
+	}
+}
+
+// WithTemplateEngine injects a custom template engine.
+func WithTemplateEngine(engine template.Engine) Option {
+	return func(c *Client) {
+		if engine != nil {
+			c.template = engine
+		}
+	}
+}
+
+// WithLogger injects a custom logger implementation.
+func WithLogger(logger logging.Logger) Option {
+	return func(c *Client) {
+		if logger != nil {
+			c.logger = logger
+		}
+	}
+}
+
+// WithHTTPClient injects a custom HTTP client.
+func WithHTTPClient(client httpDoer) Option {
+	return func(c *Client) {
+		if client != nil {
+			c.httpClient = client
+		}
+	}
+}
+
+// WithBaseURL overrides the Ollama base URL.
+func WithBaseURL(baseURL string) Option {
+	return func(c *Client) {
+		if strings.TrimSpace(baseURL) != "" {
+			c.baseURL = strings.TrimRight(baseURL, "/")
+		}
+	}
+}
+
+// Client provides an ai.Gen implementation backed by the Ollama REST API.
+type Client struct {
+	mu sync.Mutex
+
+	config      config.Manager
+	fileManager fileops.Manager
+	template    template.Engine
+	eventBus    events.EventBus
+	logger      logging.Logger
+
+	httpClient httpDoer
+	baseURL    string
+}
+
+// NewClient creates a new Ollama-backed ai.Gen implementation.
+func NewClient(eventBus events.EventBus, opts ...Option) (ai.Gen, error) {
+	client := &Client{
+		config:      config.NewConfigManager(),
+		fileManager: fileops.NewFileOpsManager(),
+		template:    template.NewEngine(),
+		eventBus:    eventBus,
+		logger:      logging.NewAPILogger("ollama"),
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+
+	if client.eventBus == nil {
+		client.eventBus = &events.NoOpEventBus{}
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	if client.logger == nil {
+		client.logger = logging.NewAPILogger("ollama")
+	}
+
+	if strings.TrimSpace(client.baseURL) == "" {
+		client.baseURL = client.resolveBaseURL()
+	}
+
+	if strings.TrimSpace(client.baseURL) == "" {
+		return nil, errNoBaseURL
+	}
+
+	return client, nil
+}
+
+// GenerateContent renders the prompt using string attributes and executes it.
+func (c *Client) GenerateContent(ctx context.Context, prompt ai.Prompt, debug bool, args ...string) (string, error) {
+	attrs := ai.StringsToAttr(args)
+	return c.GenerateContentAttr(ctx, prompt, debug, attrs)
+}
+
+// GenerateContentAttr renders the prompt using structured attributes and executes it.
+func (c *Client) GenerateContentAttr(ctx context.Context, prompt ai.Prompt, debug bool, attrs []ai.Attr) (string, error) {
+	rendered, err := c.renderPrompt(prompt, debug, attrs)
+	if err != nil {
+		return "", fmt.Errorf("rendering prompt: %w", err)
+	}
+
+	return c.generateWithPrompt(ctx, *rendered)
+}
+
+// CountTokens renders the prompt, estimates token usage using string attributes, and returns the result.
+func (c *Client) CountTokens(ctx context.Context, prompt ai.Prompt, debug bool, args ...string) (*ai.TokenCount, error) {
+	attrs := ai.StringsToAttr(args)
+	return c.CountTokensAttr(ctx, prompt, debug, attrs)
+}
+
+// CountTokensAttr renders the prompt, estimates token usage using structured attributes, and returns the result.
+func (c *Client) CountTokensAttr(ctx context.Context, prompt ai.Prompt, debug bool, attrs []ai.Attr) (*ai.TokenCount, error) {
+	rendered, err := c.renderPrompt(prompt, debug, attrs)
+	if err != nil {
+		return nil, fmt.Errorf("rendering prompt: %w", err)
+	}
+
+	request, err := c.buildChatRequest(*rendered, countTokensMode)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := c.sendChat(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenCount := c.buildTokenCount(response)
+	c.publishTokenCount(tokenCount)
+
+	return tokenCount, nil
+}
+
+// GetStatus reports the configured model and target endpoint.
+func (c *Client) GetStatus() *ai.Status {
+	model := c.config.GetModelConfig()
+	modelStr := fmt.Sprintf("%s, Temperature: %.2f, Max Tokens: %d", model.ModelName, model.Temperature, model.MaxTokens)
+
+	message := fmt.Sprintf("Ollama configured (endpoint: %s)", c.baseURL)
+	return &ai.Status{
+		Model:     modelStr,
+		Backend:   "ollama",
+		Connected: true,
+		Message:   message,
+	}
+}
+
+func (c *Client) generateWithPrompt(ctx context.Context, prompt ai.Prompt) (string, error) {
+	request, err := c.buildChatRequest(prompt, normalMode)
+	if err != nil {
+		return "", err
+	}
+
+	messages := append([]chatMessage(nil), request.Messages...)
+
+	for iteration := 0; iteration < maxToolIterations; iteration++ {
+		request.Messages = messages
+
+		response, err := c.sendChat(ctx, request)
+		if err != nil {
+			return "", err
+		}
+
+		c.publishTokenCount(c.buildTokenCount(response))
+
+		assistant := response.Message
+		if content := strings.TrimSpace(assistant.Content.Text()); content != "" {
+			notification := events.NotificationEvent{Message: content}
+			c.eventBus.Publish(notification.Topic(), notification)
+		}
+
+		messages = append(messages, assistant.toChatMessage())
+
+		if len(assistant.ToolCalls) == 0 {
+			responseText := strings.TrimSpace(assistant.Content.Text())
+			if responseText == "" {
+				return "", errEmptyResponse
+			}
+			return responseText, nil
+		}
+
+		if len(prompt.Handlers) == 0 {
+			return "", errToolCallNoHandler
+		}
+
+		toolMessages, err := c.executeToolCalls(ctx, assistant.ToolCalls, prompt.Handlers)
+		if err != nil {
+			return "", err
+		}
+		messages = append(messages, toolMessages...)
+	}
+
+	return "", fmt.Errorf("exceeded maximum tool call iterations (%d) without completion", maxToolIterations)
+}
+
+func (c *Client) executeToolCalls(ctx context.Context, calls []toolCall, handlers map[string]ai.HandlerFunc) ([]chatMessage, error) {
+	messages := make([]chatMessage, 0, len(calls))
+
+	for _, call := range calls {
+		handler := handlers[call.Function.Name]
+		if handler == nil {
+			return nil, fmt.Errorf("no handler registered for function %q", call.Function.Name)
+		}
+
+		args, err := call.Function.ArgumentsAsMap()
+		if err != nil {
+			return nil, fmt.Errorf("invalid arguments for function %q: %w", call.Function.Name, err)
+		}
+
+		result, err := handler(ctx, args)
+		if err != nil {
+			return nil, fmt.Errorf("handler for function %q failed: %w", call.Function.Name, err)
+		}
+
+		payload, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("unable to marshal response for function %q: %w", call.Function.Name, err)
+		}
+
+		messages = append(messages, chatMessage{
+			Role:       "tool",
+			Content:    newMessageContentFromText(string(payload)),
+			ToolCallID: call.ID,
+		})
+	}
+
+	return messages, nil
+}
+
+func (c *Client) buildChatRequest(prompt ai.Prompt, mode requestMode) (chatRequest, error) {
+	modelName := c.resolveModelName(prompt.ModelName)
+	if strings.TrimSpace(modelName) == "" {
+		return chatRequest{}, errors.New("no Ollama model configured")
+	}
+
+	messages := c.buildMessages(prompt)
+
+	req := chatRequest{
+		Model:    modelName,
+		Messages: messages,
+		Stream:   false,
+		Options:  c.buildOptions(prompt, mode),
+	}
+
+	if len(prompt.Functions) > 0 {
+		req.Tools = mapFunctions(prompt.Functions)
+	}
+
+	if prompt.ResponseSchema != nil {
+		format, err := schemaToFormat(prompt)
+		if err != nil {
+			return chatRequest{}, err
+		}
+		req.Format = format
+	}
+
+	return req, nil
+}
+
+func (c *Client) buildMessages(prompt ai.Prompt) []chatMessage {
+	var messages []chatMessage
+
+	if instruction := strings.TrimSpace(prompt.Instruction); instruction != "" {
+		messages = append(messages, chatMessage{
+			Role:    "system",
+			Content: newMessageContentFromText(instruction),
+		})
+	}
+
+	parts := []messagePart{}
+	if text := strings.TrimSpace(prompt.Text); text != "" {
+		parts = append(parts, messagePart{
+			Type: "text",
+			Text: text,
+		})
+	}
+
+	for _, img := range prompt.Images {
+		if img == nil || len(img.Data) == 0 {
+			continue
+		}
+		dataURL := c.encodeImage(img)
+		if dataURL == "" {
+			continue
+		}
+		parts = append(parts, messagePart{
+			Type:  "image",
+			Image: dataURL,
+		})
+	}
+
+	if len(parts) == 0 {
+		messages = append(messages, chatMessage{
+			Role:    "user",
+			Content: newMessageContentFromText(""),
+		})
+		return messages
+	}
+
+	messages = append(messages, chatMessage{
+		Role:    "user",
+		Content: newMessageContent(parts),
+	})
+
+	return messages
+}
+
+func (c *Client) buildOptions(prompt ai.Prompt, mode requestMode) map[string]any {
+	opts := map[string]any{}
+	modelCfg := c.config.GetModelConfig()
+
+	maxTokens := prompt.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = modelCfg.MaxTokens
+	}
+	if maxTokens > 0 {
+		opts["num_predict"] = maxTokens
+	}
+
+	temperature := prompt.Temperature
+	if temperature <= 0 {
+		temperature = modelCfg.Temperature
+	}
+	if temperature > 0 {
+		opts["temperature"] = temperature
+	}
+
+	topP := prompt.TopP
+	if topP <= 0 {
+		topP = modelCfg.TopP
+	}
+	if topP > 0 && topP < 1.0 {
+		opts["top_p"] = topP
+	}
+
+	if mode == countTokensMode {
+		opts["num_predict"] = tokenCountPredict
+	}
+
+	if len(opts) == 0 {
+		return nil
+	}
+	return opts
+}
+
+func (c *Client) sendChat(ctx context.Context, req chatRequest) (*chatResponse, error) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := c.baseURL + chatEndpoint
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	for key, values := range ai.DefaultHTTPHeaders() {
+		for _, value := range values {
+			httpReq.Header.Add(key, value)
+		}
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("ollama chat request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading ollama response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("ollama chat request failed: status %s: %s", resp.Status, string(body))
+	}
+
+	var response chatResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("decoding ollama response: %w", err)
+	}
+
+	return &response, nil
+}
+
+func (c *Client) renderPrompt(prompt ai.Prompt, debug bool, attrs []ai.Attr) (*ai.Prompt, error) {
+	if debug {
+		if err := c.saveObjectToTmpFile(prompt, fmt.Sprintf("%s-initial-prompt.yaml", prompt.Name)); err != nil {
+			return nil, err
+		}
+		if err := c.saveObjectToTmpFile(attrs, fmt.Sprintf("%s-attrs.yaml", prompt.Name)); err != nil {
+			return nil, err
+		}
+	}
+
+	rendered, err := ai.RenderPrompt(prompt, c.mapAttr(attrs))
+	if err != nil {
+		return nil, fmt.Errorf("rendering template: %w", err)
+	}
+
+	if debug {
+		if err := c.saveObjectToTmpFile(rendered, fmt.Sprintf("%s-final-prompt.yaml", rendered.Name)); err != nil {
+			return nil, err
+		}
+	}
+
+	return &rendered, nil
+}
+
+func (c *Client) publishTokenCount(tokenCount *ai.TokenCount) {
+	if tokenCount == nil {
+		return
+	}
+	event := events.TokenCountEvent{
+		InputTokens:  tokenCount.InputTokens,
+		OutputTokens: tokenCount.OutputTokens,
+		TotalTokens:  tokenCount.TotalTokens,
+	}
+	c.eventBus.Publish(event.Topic(), event)
+}
+
+func (c *Client) buildTokenCount(response *chatResponse) *ai.TokenCount {
+	if response == nil {
+		return nil
+	}
+
+	input := int32(response.PromptEvalCount)
+	output := int32(response.EvalCount)
+	total := input + output
+
+	return &ai.TokenCount{
+		TotalTokens:  total,
+		InputTokens:  input,
+		OutputTokens: output,
+	}
+}
+
+func (c *Client) saveObjectToTmpFile(object interface{}, filename string) error {
+	filePath := filepath.Join("tmp", filename)
+	return c.fileManager.WriteObjectAsYAML(filePath, object)
+}
+
+func (c *Client) resolveBaseURL() string {
+	if env := strings.TrimSpace(c.config.GetStringWithDefault("GENIE_OLLAMA_BASE_URL", "")); env != "" {
+		return strings.TrimRight(env, "/")
+	}
+	if env := strings.TrimSpace(c.config.GetStringWithDefault("OLLAMA_HOST", "")); env != "" {
+		if strings.HasPrefix(env, "http://") || strings.HasPrefix(env, "https://") {
+			return strings.TrimRight(env, "/")
+		}
+		return "http://" + strings.TrimRight(env, "/")
+	}
+	return defaultBaseURL
+}
+
+func (c *Client) encodeImage(img *ai.Image) string {
+	if img == nil || len(img.Data) == 0 {
+		return ""
+	}
+
+	mimeType := strings.TrimSpace(img.Type)
+	if mimeType == "" {
+		mimeType = "image/png"
+	}
+	data := base64.StdEncoding.EncodeToString(img.Data)
+	return fmt.Sprintf("data:%s;base64,%s", mimeType, data)
+}
+
+func (c *Client) mapAttr(attrs []ai.Attr) map[string]string {
+	result := make(map[string]string, len(attrs))
+	for _, attr := range attrs {
+		result[attr.Key] = attr.Value
+	}
+	return result
+}
+
+func (c *Client) resolveModelName(promptModel string) string {
+	if strings.TrimSpace(promptModel) != "" {
+		return promptModel
+	}
+
+	model := c.config.GetModelConfig()
+	if strings.TrimSpace(model.ModelName) != "" {
+		return model.ModelName
+	}
+
+	return ""
+}
+
+type requestMode int
+
+const (
+	normalMode requestMode = iota
+	countTokensMode
+)

--- a/pkg/llm/ollama/client_test.go
+++ b/pkg/llm/ollama/client_test.go
@@ -1,0 +1,256 @@
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kcaldas/genie/pkg/ai"
+	"github.com/kcaldas/genie/pkg/events"
+	"github.com/kcaldas/genie/pkg/logging"
+)
+
+func TestClient_GenerateContent_SimpleResponse(t *testing.T) {
+	t.Parallel()
+
+	mockHTTP := newMockHTTPClient(t, func(call int, req chatRequest) chatResponse {
+		require.Equal(t, 0, call)
+		return chatResponse{
+			Model: "llama3",
+			Message: responseMessage{
+				Role: "assistant",
+				Content: responseContent{
+					parts: []messagePart{{Type: "text", Text: "Hello there!"}},
+				},
+			},
+			PromptEvalCount: 12,
+			EvalCount:       4,
+		}
+	})
+
+	rawClient, err := NewClient(
+		&events.NoOpEventBus{},
+		WithBaseURL("http://test.local"),
+		WithHTTPClient(mockHTTP),
+		WithLogger(logging.NewDisabledLogger()),
+	)
+	require.NoError(t, err)
+	client := rawClient.(*Client)
+
+	prompt := ai.Prompt{
+		Name:        "greeting",
+		Instruction: "You are a helpful assistant.",
+		Text:        "Say hello.",
+		ModelName:   "llama3",
+	}
+
+	resp, err := client.GenerateContent(context.Background(), prompt, false)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello there!", resp)
+
+	require.Len(t, mockHTTP.requests, 1)
+	request := mockHTTP.requests[0]
+	assert.Equal(t, "llama3", request.Model)
+	require.Len(t, request.Messages, 2)
+	assert.Equal(t, "system", request.Messages[0].Role)
+	assert.Equal(t, "You are a helpful assistant.", request.Messages[0].Content.Parts[0].Text)
+	assert.Equal(t, "user", request.Messages[1].Role)
+	assert.Equal(t, "Say hello.", request.Messages[1].Content.Parts[0].Text)
+	assert.False(t, request.Stream)
+}
+
+func TestClient_GenerateContent_WithToolCall(t *testing.T) {
+	t.Parallel()
+
+	mockHTTP := newMockHTTPClient(t,
+		func(call int, req chatRequest) chatResponse {
+			require.Equal(t, 0, call)
+			require.Len(t, req.Messages, 1)
+			return chatResponse{
+				Model: "llama3",
+				Message: responseMessage{
+					Role: "assistant",
+					Content: responseContent{
+						parts: []messagePart{{Type: "text", Text: ""}},
+					},
+					ToolCalls: []toolCall{
+						{
+							ID:   "call_1",
+							Type: "function",
+							Function: toolCallFunction{
+								Name:      "get_weather",
+								Arguments: json.RawMessage(`{"location":"Lisbon"}`),
+							},
+						},
+					},
+				},
+				PromptEvalCount: 20,
+			}
+		},
+		func(call int, req chatRequest) chatResponse {
+			require.Equal(t, 1, call)
+			require.Len(t, req.Messages, 3)
+			toolMsg := req.Messages[2]
+			assert.Equal(t, "tool", toolMsg.Role)
+			assert.Equal(t, "call_1", toolMsg.ToolCallID)
+			assert.JSONEq(t, `{"temperature":22}`, toolMsg.Content.Parts[0].Text)
+
+			return chatResponse{
+				Model: "llama3",
+				Message: responseMessage{
+					Role: "assistant",
+					Content: responseContent{
+						parts: []messagePart{{Type: "text", Text: "It is sunny and 22°C."}},
+					},
+				},
+				PromptEvalCount: 24,
+				EvalCount:       10,
+			}
+		},
+	)
+
+	rawClient, err := NewClient(
+		&events.NoOpEventBus{},
+		WithBaseURL("http://test.local"),
+		WithHTTPClient(mockHTTP),
+		WithLogger(logging.NewDisabledLogger()),
+	)
+	require.NoError(t, err)
+	client := rawClient.(*Client)
+
+	handlerInvoked := false
+	prompt := ai.Prompt{
+		Name:      "weather",
+		Text:      "What's the weather?",
+		ModelName: "llama3",
+		Functions: []*ai.FunctionDeclaration{
+			{
+				Name: "get_weather",
+				Parameters: &ai.Schema{
+					Type: ai.TypeObject,
+				},
+			},
+		},
+		Handlers: map[string]ai.HandlerFunc{
+			"get_weather": func(ctx context.Context, attr map[string]any) (map[string]any, error) {
+				handlerInvoked = true
+				assert.Equal(t, map[string]any{"location": "Lisbon"}, attr)
+				return map[string]any{"temperature": 22}, nil
+			},
+		},
+	}
+
+	resp, err := client.GenerateContent(context.Background(), prompt, false)
+	require.NoError(t, err)
+	assert.Equal(t, "It is sunny and 22°C.", resp)
+	assert.True(t, handlerInvoked)
+	assert.Equal(t, 2, mockHTTP.callCount)
+}
+
+func TestClient_CountTokens(t *testing.T) {
+	t.Parallel()
+
+	mockHTTP := newMockHTTPClient(t, func(call int, req chatRequest) chatResponse {
+		require.Equal(t, 0, call)
+		if assert.NotNil(t, req.Options) {
+			value, ok := req.Options["num_predict"]
+			require.True(t, ok)
+			switch num := value.(type) {
+			case float64:
+				assert.Equal(t, float64(tokenCountPredict), num)
+			case int:
+				assert.Equal(t, tokenCountPredict, num)
+			default:
+				t.Fatalf("unexpected type for num_predict: %T", value)
+			}
+		}
+
+		return chatResponse{
+			Model: "llama3",
+			Message: responseMessage{
+				Role: "assistant",
+				Content: responseContent{
+					parts: []messagePart{{Type: "text", Text: ""}},
+				},
+			},
+			PromptEvalCount: 42,
+			EvalCount:       0,
+		}
+	})
+
+	rawClient, err := NewClient(
+		&events.NoOpEventBus{},
+		WithBaseURL("http://test.local"),
+		WithHTTPClient(mockHTTP),
+		WithLogger(logging.NewDisabledLogger()),
+	)
+	require.NoError(t, err)
+	client := rawClient.(*Client)
+
+	prompt := ai.Prompt{
+		Name:      "count",
+		Text:      "Count these tokens",
+		ModelName: "llama3",
+	}
+
+	count, err := client.CountTokens(context.Background(), prompt, false)
+	require.NoError(t, err)
+	require.NotNil(t, count)
+	assert.Equal(t, int32(42), count.TotalTokens)
+	assert.Equal(t, int32(42), count.InputTokens)
+	assert.Equal(t, int32(0), count.OutputTokens)
+}
+
+type mockHTTPClient struct {
+	t         *testing.T
+	mu        sync.Mutex
+	handlers  []func(call int, req chatRequest) chatResponse
+	requests  []chatRequest
+	callCount int
+}
+
+func newMockHTTPClient(t *testing.T, handlers ...func(call int, req chatRequest) chatResponse) *mockHTTPClient {
+	return &mockHTTPClient{
+		t:        t,
+		handlers: handlers,
+	}
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	require.Equal(m.t, http.MethodPost, req.Method)
+
+	body, err := io.ReadAll(req.Body)
+	require.NoError(m.t, err)
+	_ = req.Body.Close()
+
+	var parsed chatRequest
+	require.NoError(m.t, json.Unmarshal(body, &parsed))
+	m.requests = append(m.requests, parsed)
+
+	if m.callCount >= len(m.handlers) {
+		require.FailNow(m.t, "mock HTTP client received more calls than handlers configured")
+	}
+
+	handler := m.handlers[m.callCount]
+	response := handler(m.callCount, parsed)
+	m.callCount++
+
+	payload, err := json.Marshal(response)
+	require.NoError(m.t, err)
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(payload)),
+		Header:     make(http.Header),
+	}, nil
+}

--- a/pkg/llm/ollama/functions.go
+++ b/pkg/llm/ollama/functions.go
@@ -1,0 +1,40 @@
+package ollama
+
+import (
+	"strings"
+
+	"github.com/kcaldas/genie/pkg/ai"
+)
+
+func mapFunctions(functions []*ai.FunctionDeclaration) []toolDefinition {
+	if len(functions) == 0 {
+		return nil
+	}
+
+	tools := make([]toolDefinition, 0, len(functions))
+	for _, fn := range functions {
+		if fn == nil {
+			continue
+		}
+
+		definition := toolDefinition{
+			Type: "function",
+			Function: toolDefinitionDetails{
+				Name: fn.Name,
+			},
+		}
+		if strings.TrimSpace(fn.Description) != "" {
+			definition.Function.Description = fn.Description
+		}
+		if schema := schemaToMap(fn.Parameters); schema != nil {
+			definition.Function.Parameters = schema
+		}
+		tools = append(tools, definition)
+	}
+
+	if len(tools) == 0 {
+		return nil
+	}
+
+	return tools
+}

--- a/pkg/llm/ollama/schema.go
+++ b/pkg/llm/ollama/schema.go
@@ -1,0 +1,126 @@
+package ollama
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kcaldas/genie/pkg/ai"
+)
+
+func schemaToFormat(prompt ai.Prompt) (map[string]any, error) {
+	if prompt.ResponseSchema == nil {
+		return nil, nil
+	}
+
+	mapped := schemaToMap(prompt.ResponseSchema)
+	if mapped == nil {
+		return nil, fmt.Errorf("response schema is empty")
+	}
+
+	return map[string]any{
+		"type": "json_schema",
+		"value": map[string]any{
+			"name":   chooseSchemaName(prompt),
+			"schema": mapped,
+		},
+	}, nil
+}
+
+func schemaToMap(schema *ai.Schema) map[string]any {
+	if schema == nil {
+		return map[string]any{
+			"type": "object",
+		}
+	}
+
+	result := map[string]any{
+		"type": mapSchemaType(schema.Type),
+	}
+
+	if schema.Format != "" {
+		result["format"] = schema.Format
+	}
+	if schema.Title != "" {
+		result["title"] = schema.Title
+	}
+	if schema.Description != "" {
+		result["description"] = schema.Description
+	}
+	if schema.Nullable {
+		result["nullable"] = true
+	}
+	if schema.Enum != nil && len(schema.Enum) > 0 {
+		result["enum"] = schema.Enum
+	}
+	if schema.Minimum != 0 {
+		result["minimum"] = schema.Minimum
+	}
+	if schema.Maximum != 0 {
+		result["maximum"] = schema.Maximum
+	}
+	if schema.MinLength > 0 {
+		result["minLength"] = schema.MinLength
+	}
+	if schema.MaxLength > 0 {
+		result["maxLength"] = schema.MaxLength
+	}
+	if schema.Pattern != "" {
+		result["pattern"] = schema.Pattern
+	}
+	if schema.MinItems > 0 {
+		result["minItems"] = schema.MinItems
+	}
+	if schema.MaxItems > 0 {
+		result["maxItems"] = schema.MaxItems
+	}
+	if schema.MinProperties > 0 {
+		result["minProperties"] = schema.MinProperties
+	}
+	if schema.MaxProperties > 0 {
+		result["maxProperties"] = schema.MaxProperties
+	}
+	if schema.Required != nil && len(schema.Required) > 0 {
+		result["required"] = schema.Required
+	}
+	if schema.Items != nil {
+		result["items"] = schemaToMap(schema.Items)
+	}
+	if schema.Properties != nil && len(schema.Properties) > 0 {
+		props := make(map[string]any, len(schema.Properties))
+		for key, value := range schema.Properties {
+			props[key] = schemaToMap(value)
+		}
+		result["properties"] = props
+	}
+
+	return result
+}
+
+func mapSchemaType(t ai.Type) string {
+	switch t {
+	case ai.TypeString:
+		return "string"
+	case ai.TypeNumber:
+		return "number"
+	case ai.TypeInteger:
+		return "integer"
+	case ai.TypeBoolean:
+		return "boolean"
+	case ai.TypeArray:
+		return "array"
+	case ai.TypeObject:
+		return "object"
+	default:
+		return "object"
+	}
+}
+
+func chooseSchemaName(prompt ai.Prompt) string {
+	if prompt.ResponseSchema != nil && prompt.ResponseSchema.Title != "" {
+		return prompt.ResponseSchema.Title
+	}
+	if strings.TrimSpace(prompt.Name) != "" {
+		return prompt.Name
+	}
+	return "response"
+}

--- a/pkg/llm/ollama/types.go
+++ b/pkg/llm/ollama/types.go
@@ -1,0 +1,239 @@
+package ollama
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type chatRequest struct {
+	Model    string           `json:"model"`
+	Messages []chatMessage    `json:"messages"`
+	Tools    []toolDefinition `json:"tools,omitempty"`
+	Stream   bool             `json:"stream"`
+	Options  map[string]any   `json:"options,omitempty"`
+	Format   map[string]any   `json:"format,omitempty"`
+}
+
+type chatMessage struct {
+	Role       string         `json:"role"`
+	Content    messageContent `json:"content"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+	ToolCalls  []toolCall     `json:"tool_calls,omitempty"`
+}
+
+type messageContent struct {
+	Parts []messagePart
+}
+
+func newMessageContent(parts []messagePart) messageContent {
+	return messageContent{Parts: parts}
+}
+
+func newMessageContentFromText(text string) messageContent {
+	if strings.TrimSpace(text) == "" {
+		return messageContent{Parts: []messagePart{{Type: "text", Text: ""}}}
+	}
+	return messageContent{Parts: []messagePart{{Type: "text", Text: text}}}
+}
+
+func (mc messageContent) MarshalJSON() ([]byte, error) {
+	if len(mc.Parts) == 0 {
+		return json.Marshal("")
+	}
+	if len(mc.Parts) == 1 && mc.Parts[0].Type == "text" {
+		return json.Marshal(mc.Parts[0].Text)
+	}
+	return json.Marshal(mc.Parts)
+}
+
+func (mc *messageContent) UnmarshalJSON(data []byte) error {
+	data = bytesTrim(data)
+	if len(data) == 0 {
+		mc.Parts = nil
+		return nil
+	}
+	if data[0] == '"' {
+		var text string
+		if err := json.Unmarshal(data, &text); err != nil {
+			return fmt.Errorf("decode message text: %w", err)
+		}
+		mc.Parts = []messagePart{{Type: "text", Text: text}}
+		return nil
+	}
+	var parts []messagePart
+	if err := json.Unmarshal(data, &parts); err != nil {
+		return fmt.Errorf("decode message content parts: %w", err)
+	}
+	mc.Parts = parts
+	return nil
+}
+
+type messagePart struct {
+	Type  string `json:"type"`
+	Text  string `json:"text,omitempty"`
+	Image string `json:"image,omitempty"`
+}
+
+type chatResponse struct {
+	Model           string          `json:"model"`
+	Message         responseMessage `json:"message"`
+	Done            bool            `json:"done"`
+	PromptEvalCount int             `json:"prompt_eval_count"`
+	EvalCount       int             `json:"eval_count"`
+	PromptEvalTime  int64           `json:"prompt_eval_duration"`
+	EvalTime        int64           `json:"eval_duration"`
+	TotalDuration   int64           `json:"total_duration"`
+	LoadDuration    int64           `json:"load_duration"`
+	Error           string          `json:"error"`
+}
+
+type responseMessage struct {
+	Role      string          `json:"role"`
+	Content   responseContent `json:"content"`
+	ToolCalls []toolCall      `json:"tool_calls"`
+}
+
+func (rm responseMessage) toChatMessage() chatMessage {
+	return chatMessage{
+		Role:      rm.Role,
+		Content:   rm.Content.toMessageContent(),
+		ToolCalls: rm.ToolCalls,
+	}
+}
+
+type responseContent struct {
+	parts []messagePart
+}
+
+func (rc responseContent) Text() string {
+	if len(rc.parts) == 0 {
+		return ""
+	}
+	var builder strings.Builder
+	for _, part := range rc.parts {
+		if part.Type == "text" && strings.TrimSpace(part.Text) != "" {
+			if builder.Len() > 0 {
+				builder.WriteString("\n")
+			}
+			builder.WriteString(part.Text)
+		}
+	}
+	return builder.String()
+}
+
+func (rc responseContent) toMessageContent() messageContent {
+	if len(rc.parts) == 0 {
+		return newMessageContentFromText("")
+	}
+	return newMessageContent(rc.parts)
+}
+
+func (rc responseContent) MarshalJSON() ([]byte, error) {
+	if len(rc.parts) == 0 {
+		return json.Marshal("")
+	}
+	if len(rc.parts) == 1 && rc.parts[0].Type == "text" {
+		return json.Marshal(rc.parts[0].Text)
+	}
+	return json.Marshal(rc.parts)
+}
+
+func (rc *responseContent) UnmarshalJSON(data []byte) error {
+	data = bytesTrim(data)
+	if len(data) == 0 {
+		rc.parts = nil
+		return nil
+	}
+	switch data[0] {
+	case '{':
+		var part messagePart
+		if err := json.Unmarshal(data, &part); err != nil {
+			return fmt.Errorf("decode message part: %w", err)
+		}
+		rc.parts = []messagePart{part}
+	case '[':
+		var parts []messagePart
+		if err := json.Unmarshal(data, &parts); err != nil {
+			return fmt.Errorf("decode message parts: %w", err)
+		}
+		rc.parts = parts
+	case '"':
+		var text string
+		if err := json.Unmarshal(data, &text); err != nil {
+			return fmt.Errorf("decode message text: %w", err)
+		}
+		rc.parts = []messagePart{{Type: "text", Text: text}}
+	default:
+		rc.parts = []messagePart{{Type: "text", Text: string(data)}}
+	}
+	return nil
+}
+
+type toolDefinition struct {
+	Type     string                `json:"type"`
+	Function toolDefinitionDetails `json:"function"`
+}
+
+type toolDefinitionDetails struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+type toolCall struct {
+	ID       string           `json:"id"`
+	Type     string           `json:"type"`
+	Function toolCallFunction `json:"function"`
+}
+
+type toolCallFunction struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+func (f toolCallFunction) ArgumentsAsMap() (map[string]any, error) {
+	if len(f.Arguments) == 0 {
+		return map[string]any{}, nil
+	}
+
+	trimmed := bytesTrim(f.Arguments)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return map[string]any{}, nil
+	}
+
+	var args map[string]any
+	if trimmed[0] == '"' {
+		var raw string
+		if err := json.Unmarshal(f.Arguments, &raw); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(raw) == "" {
+			return map[string]any{}, nil
+		}
+		if err := json.Unmarshal([]byte(raw), &args); err != nil {
+			return nil, err
+		}
+		return args, nil
+	}
+
+	if err := json.Unmarshal(f.Arguments, &args); err != nil {
+		return nil, err
+	}
+	if args == nil {
+		return map[string]any{}, nil
+	}
+	return args, nil
+}
+
+func bytesTrim(data []byte) []byte {
+	start := 0
+	end := len(data)
+	for start < end && (data[start] == ' ' || data[start] == '\n' || data[start] == '\r' || data[start] == '\t') {
+		start++
+	}
+	for end > start && (data[end-1] == ' ' || data[end-1] == '\n' || data[end-1] == '\r' || data[end-1] == '\t') {
+		end--
+	}
+	return data[start:end]
+}


### PR DESCRIPTION
  - Added pkg/llm/ollama with a full ai.Gen implementation: prompt rendering, REST calls, tool calling loop, structured
    output, vision support, and token-count estimation via prompt_eval_count/eval_count.
  - Kept Ollama-specific schema/function mapping isolated.
  - Registered the new factory in pkg/genie/wire.go/wire_gen.go so GENIE_LLM_PROVIDER=ollama just works.
  - Added focused unit tests (pkg/llm/ollama/client_test.go) using a mock HTTP client for plain replies, tool calls, and
    count-tokens flow.