### PR TITLE
Add streaming support with Gemini 3 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.24.x]
     
     steps:
     - name: Checkout code
@@ -94,7 +94,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
 
     - name: Run Gosec Security Scanner
       uses: securego/gosec@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
 
     - name: Cache Go modules
       uses: actions/cache@v4

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,5 @@
 # Multi-stage build for local development
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 # Set working directory
 WORKDIR /app

--- a/cmd/tui/controllers/chat.go
+++ b/cmd/tui/controllers/chat.go
@@ -135,6 +135,13 @@ func NewChatController(
 		}
 	})
 
+	eventBus.Subscribe("chat.chunk", func(e interface{}) {
+		if event, ok := e.(core_events.ChatChunkEvent); ok {
+			c.logger().Debug("Event consumed", "topic", event.Topic())
+			c.handleChatChunk(event)
+		}
+	})
+
 	eventBus.Subscribe("tool.executed", func(e interface{}) {
 		if event, ok := e.(core_events.ToolExecutedEvent); ok {
 			c.logger().Debug("Event consumed", "topic", event.Topic())

--- a/cmd/tui/state/chat_state.go
+++ b/cmd/tui/state/chat_state.go
@@ -66,12 +66,22 @@ func (s *ChatState) ClearMessages() {
 	s.messages = []types.Message{}
 }
 
-
-
 func (s *ChatState) GetMessageCount() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.messages)
+}
+
+func (s *ChatState) UpdateMessage(index int, update func(*types.Message)) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if index < 0 || index >= len(s.messages) {
+		return false
+	}
+	if update != nil {
+		update(&s.messages[index])
+	}
+	return true
 }
 
 func (s *ChatState) GetLastMessage() *types.Message {
@@ -97,7 +107,6 @@ func (s *ChatState) SetWaitingConfirmation(waiting bool) {
 	defer s.mu.Unlock()
 	s.waitingConfirmation = waiting
 }
-
 
 func (s *ChatState) GetMessageRange(start, count int) []types.Message {
 	s.mu.RLock()

--- a/cmd/tui/state/state_accessor.go
+++ b/cmd/tui/state/state_accessor.go
@@ -36,6 +36,10 @@ func (s *StateAccessor) UpdateMessage(index int, update func(*types.Message)) bo
 	return s.chatState.UpdateMessage(index, update)
 }
 
+func (s *StateAccessor) GetLastMessage() *types.Message {
+	return s.chatState.GetLastMessage()
+}
+
 func (s *StateAccessor) IsWaitingConfirmation() bool {
 	return s.chatState.IsWaitingConfirmation()
 }

--- a/cmd/tui/state/state_accessor.go
+++ b/cmd/tui/state/state_accessor.go
@@ -28,7 +28,13 @@ func (s *StateAccessor) ClearMessages() {
 	s.chatState.ClearMessages()
 }
 
+func (s *StateAccessor) GetMessageCount() int {
+	return s.chatState.GetMessageCount()
+}
 
+func (s *StateAccessor) UpdateMessage(index int, update func(*types.Message)) bool {
+	return s.chatState.UpdateMessage(index, update)
+}
 
 func (s *StateAccessor) IsWaitingConfirmation() bool {
 	return s.chatState.IsWaitingConfirmation()
@@ -37,7 +43,6 @@ func (s *StateAccessor) IsWaitingConfirmation() bool {
 func (s *StateAccessor) SetWaitingConfirmation(waiting bool) {
 	s.chatState.SetWaitingConfirmation(waiting)
 }
-
 
 func (s *StateAccessor) IsContextViewerActive() bool {
 	return s.uiState.IsContextViewerActive()

--- a/cmd/tui/types/interfaces.go
+++ b/cmd/tui/types/interfaces.go
@@ -39,7 +39,7 @@ type WindowProperties struct {
 
 	// Focus behavior
 	FocusStyle FocusStyle // How to show focus state
-	
+
 	// Title properties
 	Subtitle string // Subtitle shown on right side of border
 }
@@ -53,7 +53,8 @@ type IStateAccessor interface {
 	GetMessages() []Message
 	AddMessage(msg Message)
 	ClearMessages()
-
+	GetMessageCount() int
+	UpdateMessage(index int, update func(*Message)) bool
 
 	// Confirmation state
 	SetWaitingConfirmation(waiting bool)

--- a/cmd/tui/types/interfaces.go
+++ b/cmd/tui/types/interfaces.go
@@ -55,6 +55,7 @@ type IStateAccessor interface {
 	ClearMessages()
 	GetMessageCount() int
 	UpdateMessage(index int, update func(*Message)) bool
+	GetLastMessage() *Message
 
 	// Confirmation state
 	SetWaitingConfirmation(waiting bool)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/kcaldas/genie
 
-go 1.23.6
+go 1.24
+
+toolchain go1.24.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
@@ -21,7 +23,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	google.golang.org/genai v1.12.0
+	google.golang.org/genai v1.36.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -275,8 +275,8 @@ golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
-google.golang.org/genai v1.12.0 h1:0JjAdwvEAha9ZpPH5hL6dVG8bpMnRbAMCgv2f2LDnz4=
-google.golang.org/genai v1.12.0/go.mod h1:HFXR1zT3LCdLxd/NW6IOSCczOYyRAxwaShvYbgPSeVw=
+google.golang.org/genai v1.36.0 h1:sJCIjqTAmwrtAIaemtTiKkg2TO1RxnYEusTmEQ3nGxM=
+google.golang.org/genai v1.36.0/go.mod h1:A3kkl0nyBjyFlNjgxIwKq70julKbIxpSxqKO5gw/gmk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34 h1:h6p3mQqrmT1XkHVTfzLdNz1u7IhINeZkz67/xTbOuWs=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
 google.golang.org/grpc v1.73.0 h1:VIWSmpI2MegBtTuFt5/JWy2oXxtjJ/e89Z70ImfD2ok=

--- a/pkg/ai/gen_test.go
+++ b/pkg/ai/gen_test.go
@@ -24,6 +24,14 @@ func (m *MockGen) GenerateContentAttr(ctx context.Context, prompt ai.Prompt, deb
 	return mockArgs.String(0), mockArgs.Error(1)
 }
 
+func (m *MockGen) GenerateContentStream(ctx context.Context, prompt ai.Prompt, debug bool, args ...string) (ai.Stream, error) {
+	return nil, nil
+}
+
+func (m *MockGen) GenerateContentAttrStream(ctx context.Context, prompt ai.Prompt, debug bool, attrs []ai.Attr) (ai.Stream, error) {
+	return nil, nil
+}
+
 func (m *MockGen) CountTokens(ctx context.Context, p ai.Prompt, debug bool, args ...string) (*ai.TokenCount, error) {
 	mockArgs := m.Called(ctx, p, debug, args)
 	if mockArgs.Error(1) != nil {
@@ -66,4 +74,3 @@ func TestGenCancellation(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 	mockGen.AssertExpectations(t)
 }
-

--- a/pkg/events/session_events.go
+++ b/pkg/events/session_events.go
@@ -1,5 +1,9 @@
 package events
 
+import (
+	"github.com/kcaldas/genie/pkg/ai"
+)
+
 // ToolExecutedEvent represents a tool that has been executed
 type ToolExecutedEvent struct {
 	ExecutionID string
@@ -68,6 +72,7 @@ func (e UserConfirmationResponse) Topic() string {
 
 // ChatResponseEvent is published when AI generates a response
 type ChatResponseEvent struct {
+	RequestID string
 	Message   string
 	Response  string
 	Error     error
@@ -81,12 +86,24 @@ func (e ChatResponseEvent) Topic() string {
 
 // ChatStartedEvent is published when chat processing begins
 type ChatStartedEvent struct {
-	Message string
+	RequestID string
+	Message   string
 }
 
 // Topic returns the event topic for chat started events
 func (e ChatStartedEvent) Topic() string {
 	return "chat.started"
+}
+
+// ChatChunkEvent represents an incremental chunk produced while streaming.
+type ChatChunkEvent struct {
+	RequestID string
+	Chunk     *ai.StreamChunk
+}
+
+// Topic returns topic for streaming chunk events.
+func (e ChatChunkEvent) Topic() string {
+	return "chat.chunk"
 }
 
 // ToolCallMessageEvent is published when a tool call wants to display a message to the user

--- a/pkg/genie/chat_options.go
+++ b/pkg/genie/chat_options.go
@@ -22,6 +22,8 @@ type ChatImage struct {
 type chatRequestOptions struct {
 	images     []ChatImage
 	promptData map[string]string
+	stream     bool
+	requestID  string
 }
 
 // ChatOption configures a chat request. Options are optional – existing
@@ -132,4 +134,11 @@ func mergePromptImages(base []*ai.Image, extras []ChatImage) []*ai.Image {
 		return nil
 	}
 	return merged
+}
+
+// WithStreaming toggles streaming mode for a chat request.
+func WithStreaming(enabled bool) ChatOption {
+	return func(opts *chatRequestOptions) {
+		opts.stream = enabled
+	}
 }

--- a/pkg/genie/core.go
+++ b/pkg/genie/core.go
@@ -3,11 +3,14 @@ package genie
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"maps"
 	"os"
 	"strconv"
+	"strings"
 
+	"github.com/google/uuid"
 	"github.com/kcaldas/genie/pkg/ai"
 	"github.com/kcaldas/genie/pkg/config"
 	"github.com/kcaldas/genie/pkg/ctx"
@@ -16,9 +19,12 @@ import (
 	"github.com/kcaldas/genie/pkg/tools"
 )
 
+type requestIDContextKey struct{}
+
 // PromptRunner executes prompts - allows mocking prompt execution for testing
 type PromptRunner interface {
 	RunPrompt(ctx context.Context, prompt *ai.Prompt, data map[string]string, eventBus events.EventBus) (string, error)
+	RunPromptStream(ctx context.Context, prompt *ai.Prompt, data map[string]string, eventBus events.EventBus) (string, error)
 	CountTokens(ctx context.Context, prompt *ai.Prompt, data map[string]string, eventBus events.EventBus) (*ai.TokenCount, error)
 	GetStatus() *ai.Status
 }
@@ -39,6 +45,45 @@ func NewDefaultPromptRunner(llmClient ai.Gen, debug bool) PromptRunner {
 
 func (r *DefaultPromptRunner) RunPrompt(ctx context.Context, prompt *ai.Prompt, data map[string]string, eventBus events.EventBus) (string, error) {
 	return r.llmClient.GenerateContentAttr(ctx, *prompt, r.debug, ai.MapToAttr(data))
+}
+
+func (r *DefaultPromptRunner) RunPromptStream(ctx context.Context, prompt *ai.Prompt, data map[string]string, eventBus events.EventBus) (string, error) {
+	stream, err := r.llmClient.GenerateContentAttrStream(ctx, *prompt, r.debug, ai.MapToAttr(data))
+	if err != nil {
+		return "", err
+	}
+	if stream == nil {
+		return "", fmt.Errorf("streaming not supported by provider")
+	}
+	defer stream.Close()
+
+	var builder strings.Builder
+	requestID := requestIDFromContext(ctx)
+
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+		if chunk == nil {
+			continue
+		}
+		if eventBus != nil && requestID != "" {
+			chunkEvent := events.ChatChunkEvent{
+				RequestID: requestID,
+				Chunk:     chunk,
+			}
+			eventBus.Publish(chunkEvent.Topic(), chunkEvent)
+		}
+		if chunk.Text != "" {
+			builder.WriteString(chunk.Text)
+		}
+	}
+
+	return builder.String(), nil
 }
 
 func (r *DefaultPromptRunner) CountTokens(ctx context.Context, prompt *ai.Prompt, data map[string]string, eventBus events.EventBus) (*ai.TokenCount, error) {
@@ -179,10 +224,14 @@ func (g *core) Chat(ctx context.Context, message string, opts ...ChatOption) err
 	}
 
 	chatOpts := applyChatOptions(opts...)
+	if chatOpts.requestID == "" {
+		chatOpts.requestID = uuid.NewString()
+	}
 
 	// Publish started event immediately
 	startEvent := events.ChatStartedEvent{
-		Message: message,
+		RequestID: chatOpts.requestID,
+		Message:   message,
 	}
 	g.eventBus.Publish(startEvent.Topic(), startEvent)
 
@@ -193,9 +242,10 @@ func (g *core) Chat(ctx context.Context, message string, opts ...ChatOption) err
 			if r := recover(); r != nil {
 				panicErr := fmt.Errorf("internal error: %v", r)
 				responseEvent := events.ChatResponseEvent{
-					Message:  message,
-					Response: "",
-					Error:    panicErr,
+					RequestID: options.requestID,
+					Message:   message,
+					Response:  "",
+					Error:     panicErr,
 				}
 				g.eventBus.Publish(responseEvent.Topic(), responseEvent)
 			}
@@ -205,9 +255,10 @@ func (g *core) Chat(ctx context.Context, message string, opts ...ChatOption) err
 
 		// Publish response event (success or error)
 		responseEvent := events.ChatResponseEvent{
-			Message:  message,
-			Response: response,
-			Error:    err,
+			RequestID: options.requestID,
+			Message:   message,
+			Response:  response,
+			Error:     err,
 		}
 		g.eventBus.Publish(responseEvent.Topic(), responseEvent)
 	}(chatOpts)
@@ -363,7 +414,12 @@ func (g *core) processChat(ctx context.Context, message string, options chatRequ
 		promptData["image_count"] = strconv.Itoa(len(options.images))
 	}
 
-	response, err := g.promptRunner.RunPrompt(ctx, prompt, promptData, g.eventBus)
+	var response string
+	if options.stream {
+		response, err = g.promptRunner.RunPromptStream(ctx, prompt, promptData, g.eventBus)
+	} else {
+		response, err = g.promptRunner.RunPrompt(ctx, prompt, promptData, g.eventBus)
+	}
 	if err != nil {
 		return "", fmt.Errorf("failed to execute chat prompt: %w", err)
 	}
@@ -405,4 +461,14 @@ func (g *core) preparePromptData(ctx context.Context, message string) map[string
 	promptData["message"] = message
 
 	return promptData
+}
+
+func requestIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if value, ok := ctx.Value(requestIDContextKey{}).(string); ok {
+		return value
+	}
+	return ""
 }

--- a/pkg/genie/core.go
+++ b/pkg/genie/core.go
@@ -391,6 +391,9 @@ func (g *core) processChat(ctx context.Context, message string, options chatRequ
 		personaID = persona.GetID()
 	}
 	ctx = context.WithValue(ctx, "persona", personaID)
+	if options.requestID != "" {
+		ctx = context.WithValue(ctx, requestIDContextKey{}, options.requestID)
+	}
 
 	// Create prompt context with structured context parts + message
 	promptData := g.preparePromptData(ctx, message)

--- a/pkg/llm/anthropic/client.go
+++ b/pkg/llm/anthropic/client.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	defaultMaxToolIterations = 20
+	defaultMaxToolIterations = 200
 	defaultClaudeModel       = "claude-3-5-sonnet-20241022"
 	defaultSchemaName        = "response"
 )

--- a/pkg/llm/anthropic/client_test.go
+++ b/pkg/llm/anthropic/client_test.go
@@ -9,6 +9,7 @@ import (
 
 	anthropic_sdk "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 	"github.com/anthropics/anthropic-sdk-go/shared/constant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,6 +60,10 @@ func (m *mockMessageClient) CountTokens(ctx context.Context, body anthropic_sdk.
 		require.FailNow(m.t, "mock message client has no count token response configured")
 	}
 	return m.countResponse, nil
+}
+
+func (m *mockMessageClient) NewStreaming(ctx context.Context, body anthropic_sdk.MessageNewParams, _ ...option.RequestOption) *ssestream.Stream[anthropic_sdk.MessageStreamEventUnion] {
+	return nil
 }
 
 func TestClient_GenerateContent_SimpleResponse(t *testing.T) {

--- a/pkg/llm/genai/client.go
+++ b/pkg/llm/genai/client.go
@@ -1,12 +1,10 @@
 package genai
-
 import (
 	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
-
 	"github.com/kcaldas/genie/pkg/ai"
 	"github.com/kcaldas/genie/pkg/config"
 	"github.com/kcaldas/genie/pkg/events"
@@ -16,17 +14,14 @@ import (
 	"github.com/kcaldas/genie/pkg/template"
 	"google.golang.org/genai"
 )
-
 // Backend represents the GenAI backend to use
 type Backend string
-
 const (
 	BackendVertexAI          Backend    = "vertex"
 	BackendGeminiAPI         Backend    = "gemini"
 	roleTool                 genai.Role = "tool"
-	defaultMaxToolIterations            = 20
+	defaultMaxToolIterations            = 200
 )
-
 // Client implements the ai.Gen interface using Google's unified GenAI package
 // Supports both Vertex AI and Gemini API backends
 type Client struct {
@@ -38,26 +33,20 @@ type Client struct {
 	EventBus        events.EventBus
 	// Allows tests to intercept generate content calls.
 	callGenerateContentFn func(ctx context.Context, modelName string, contents []*genai.Content, config *genai.GenerateContentConfig, handlers map[string]ai.HandlerFunc) (*genai.GenerateContentResponse, error)
-
 	// Lazy initialization
 	mu          sync.Mutex
 	initialized bool
 	initError   error
 }
-
 var _ ai.Gen = &Client{}
-
 // NewClient creates a new unified GenAI client that will initialize lazily
 func NewClient(eventBus events.EventBus) (ai.Gen, error) {
 	configManager := config.NewConfigManager()
-
 	// Determine backend preference and check basic configuration
 	backend := Backend(configManager.GetStringWithDefault("GENAI_BACKEND", "gemini"))
-
 	// Check that at least one backend has basic configuration
 	hasGeminiKey := configManager.GetStringWithDefault("GEMINI_API_KEY", "") != ""
 	hasVertexProject := configManager.GetStringWithDefault("GOOGLE_CLOUD_PROJECT", "") != ""
-
 	if !hasGeminiKey && !hasVertexProject {
 		return nil, fmt.Errorf("no valid AI backend configured. Please set up one of the following:\n\n" +
 			"Option 1 - Gemini API (recommended):\n" +
@@ -67,7 +56,6 @@ func NewClient(eventBus events.EventBus) (ai.Gen, error) {
 			"  export GOOGLE_CLOUD_PROJECT=your-project-id\n" +
 			"  Requires Google Cloud setup and authentication\n")
 	}
-
 	return &Client{
 		Client:          nil, // Will be created on first use
 		FileManager:     fileops.NewFileOpsManager(),
@@ -78,20 +66,16 @@ func NewClient(eventBus events.EventBus) (ai.Gen, error) {
 		EventBus:        eventBus,
 	}, nil
 }
-
 // ensureInitialized initializes the GenAI client (idempotent, safe to call multiple times)
 func (g *Client) ensureInitialized(ctx context.Context) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-
 	// If already initialized (successfully or with error), return cached result
 	if g.initialized {
 		return g.initError
 	}
-
 	// Mark as initialized to prevent multiple attempts
 	g.initialized = true
-
 	// Try to create client based on backend preference
 	client, actualBackend, err := createClientWithBackend(g.Config, g.Backend)
 	if err != nil {
@@ -102,7 +86,6 @@ func (g *Client) ensureInitialized(ctx context.Context) error {
 		} else {
 			fallbackBackend = BackendGeminiAPI
 		}
-
 		client, actualBackend, err = createClientWithBackend(g.Config, fallbackBackend)
 		if err != nil {
 			// Both backends failed - provide helpful message with both options
@@ -116,19 +99,15 @@ func (g *Client) ensureInitialized(ctx context.Context) error {
 			return g.initError
 		}
 	}
-
 	// Success - store the client and backend
 	g.Client = client
 	g.Backend = actualBackend
 	g.initError = nil
-
 	return nil
 }
-
 // createClientWithBackend attempts to create a client with the specified backend
 func createClientWithBackend(configManager config.Manager, backend Backend) (*genai.Client, Backend, error) {
 	ctx := context.Background()
-
 	switch backend {
 	case BackendGeminiAPI:
 		// Try Gemini API (API key based)
@@ -136,128 +115,101 @@ func createClientWithBackend(configManager config.Manager, backend Backend) (*ge
 		if apiKey == "" {
 			return nil, "", fmt.Errorf("GEMINI_API_KEY not configured")
 		}
-
 		cfg := &genai.ClientConfig{
 			APIKey:  apiKey,
 			Backend: genai.BackendGeminiAPI,
 		}
 		cfg.HTTPOptions.Headers = ai.DefaultHTTPHeaders()
-
 		client, err := genai.NewClient(ctx, cfg)
 		if err != nil {
 			return nil, "", fmt.Errorf("error creating Gemini API client: %w", err)
 		}
-
 		return client, BackendGeminiAPI, nil
-
 	case BackendVertexAI:
 		// Try Vertex AI (GCP project based)
 		projectID, err := configManager.GetString("GOOGLE_CLOUD_PROJECT")
 		if err != nil {
 			return nil, "", fmt.Errorf("GOOGLE_CLOUD_PROJECT not configured")
 		}
-
 		location := configManager.GetStringWithDefault("GOOGLE_CLOUD_LOCATION", "us-central1")
-
 		cfg := &genai.ClientConfig{
 			Project:  projectID,
 			Location: location,
 			Backend:  genai.BackendVertexAI,
 		}
 		cfg.HTTPOptions.Headers = ai.DefaultHTTPHeaders()
-
 		client, err := genai.NewClient(ctx, cfg)
 		if err != nil {
 			return nil, "", fmt.Errorf("error creating Vertex AI client: %w", err)
 		}
-
 		return client, BackendVertexAI, nil
-
 	default:
 		return nil, "", fmt.Errorf("unsupported backend: %s", backend)
 	}
 }
-
 func (g *Client) GenerateContent(ctx context.Context, p ai.Prompt, debug bool, args ...string) (string, error) {
 	// Ensure client is initialized
 	if err := g.ensureInitialized(ctx); err != nil {
 		return "", err
 	}
-
 	attrs := ai.StringsToAttr(args)
 	prompt, err := renderPrompt(g.FileManager, p, debug, attrs)
 	if err != nil {
 		return "", fmt.Errorf("error rendering prompt: %w", err)
 	}
-
 	return g.generateContentWithPrompt(ctx, *prompt, debug)
 }
-
 func (g *Client) GenerateContentAttr(ctx context.Context, prompt ai.Prompt, debug bool, attrs []ai.Attr) (string, error) {
 	// Ensure client is initialized
 	if err := g.ensureInitialized(ctx); err != nil {
 		return "", err
 	}
-
 	p, err := renderPrompt(g.FileManager, prompt, debug, attrs)
 	if err != nil {
 		return "", fmt.Errorf("error rendering prompt: %w", err)
 	}
-
 	return g.generateContentWithPrompt(ctx, *p, debug)
 }
-
 func (g *Client) GenerateContentStream(ctx context.Context, p ai.Prompt, debug bool, args ...string) (ai.Stream, error) {
 	if err := g.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
-
 	attrs := ai.StringsToAttr(args)
 	prompt, err := renderPrompt(g.FileManager, p, debug, attrs)
 	if err != nil {
 		return nil, fmt.Errorf("error rendering prompt: %w", err)
 	}
-
 	return g.generateContentStreamWithPrompt(ctx, *prompt)
 }
-
 func (g *Client) GenerateContentAttrStream(ctx context.Context, prompt ai.Prompt, debug bool, attrs []ai.Attr) (ai.Stream, error) {
 	if err := g.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
-
 	rendered, err := renderPrompt(g.FileManager, prompt, debug, attrs)
 	if err != nil {
 		return nil, fmt.Errorf("error rendering prompt: %w", err)
 	}
-
 	return g.generateContentStreamWithPrompt(ctx, *rendered)
 }
-
 func (g *Client) CountTokens(ctx context.Context, p ai.Prompt, debug bool, args ...string) (*ai.TokenCount, error) {
 	// Ensure client is initialized
 	if err := g.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
-
 	attrs := ai.StringsToAttr(args)
 	return g.CountTokensAttr(ctx, p, debug, attrs)
 }
-
 func (g *Client) CountTokensAttr(ctx context.Context, p ai.Prompt, debug bool, attrs []ai.Attr) (*ai.TokenCount, error) {
 	// Ensure client is initialized
 	if err := g.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
-
 	prompt, err := renderPrompt(g.FileManager, p, debug, attrs)
 	if err != nil {
 		return nil, fmt.Errorf("error rendering prompt: %w", err)
 	}
-
 	return g.countTokensWithPrompt(ctx, *prompt)
 }
-
 // GetStatus returns the connection status and backend information
 func (g *Client) GetStatus() *ai.Status {
 	model := g.Config.GetModelConfig()
@@ -270,7 +222,6 @@ func (g *Client) GetStatus() *ai.Status {
 			return &ai.Status{Model: modelStr, Connected: false, Backend: "gemini", Message: "GEMINI_API_KEY not configured"}
 		}
 		return &ai.Status{Model: modelStr, Connected: true, Backend: "gemini", Message: "Gemini API configured"}
-
 	case BackendVertexAI:
 		projectID := g.Config.GetStringWithDefault("GOOGLE_CLOUD_PROJECT", "")
 		if projectID == "" {
@@ -278,24 +229,19 @@ func (g *Client) GetStatus() *ai.Status {
 		}
 		location := g.Config.GetStringWithDefault("GOOGLE_CLOUD_LOCATION", "us-central1")
 		return &ai.Status{Model: modelStr, Connected: true, Backend: "vertex", Message: fmt.Sprintf("Vertex AI configured (project: %s, location: %s)", projectID, location)}
-
 	default:
 		return &ai.Status{Model: modelStr, Connected: false, Backend: "unknown", Message: fmt.Sprintf("Unknown backend: %s", g.Backend)}
 	}
 }
-
 func (g *Client) generateContentWithPrompt(ctx context.Context, p ai.Prompt, debug bool) (string, error) {
 	contents := g.buildInitialContents(p)
 	config := g.buildGenerateConfig(p)
-
 	limit := normalizeToolIterations(p.MaxToolIterations)
-
 	// Generate content with function calling support
 	result, toolUsed, err := g.invokeGenerateContent(ctx, p.ModelName, contents, config, p.Handlers, limit)
 	if err != nil {
 		return "", fmt.Errorf("error generating content: %w", err)
 	}
-
 	// Extract text from the response
 	if len(result.Candidates) == 0 {
 		if toolUsed {
@@ -303,7 +249,6 @@ func (g *Client) generateContentWithPrompt(ctx context.Context, p ai.Prompt, deb
 		}
 		return "", fmt.Errorf("no response candidates")
 	}
-
 	candidate := result.Candidates[0]
 	if candidate.Content == nil {
 		if toolUsed {
@@ -311,7 +256,6 @@ func (g *Client) generateContentWithPrompt(ctx context.Context, p ai.Prompt, deb
 		}
 		return "", fmt.Errorf("no content in response candidate")
 	}
-
 	response := g.joinContentParts(candidate.Content)
 	if strings.TrimSpace(response) == "" {
 		if toolUsed {
@@ -321,27 +265,20 @@ func (g *Client) generateContentWithPrompt(ctx context.Context, p ai.Prompt, deb
 	}
 	return response, nil
 }
-
 func (g *Client) generateContentStreamWithPrompt(ctx context.Context, p ai.Prompt) (ai.Stream, error) {
 	contents := g.buildInitialContents(p)
 	config := g.buildGenerateConfig(p)
 	limit := normalizeToolIterations(p.MaxToolIterations)
-
 	streamCtx, cancel := context.WithCancel(ctx)
 	ch := make(chan llmshared.StreamResult, 1)
-
 	go g.runContentStream(streamCtx, ch, p.ModelName, contents, config, p.Handlers, limit)
-
 	return llmshared.NewChunkStream(cancel, ch), nil
 }
-
 func (g *Client) runContentStream(ctx context.Context, ch chan<- llmshared.StreamResult, modelName string, contents []*genai.Content, config *genai.GenerateContentConfig, handlers map[string]ai.HandlerFunc, maxIterations int) {
 	defer close(ch)
-
 	currentContents := make([]*genai.Content, len(contents))
 	copy(currentContents, contents)
 	currentConfig := config
-
 	for iteration := 0; ; iteration++ {
 		done, updatedContents, err := g.streamGenerationStep(ctx, ch, modelName, currentContents, currentConfig, handlers)
 		if err != nil {
@@ -370,11 +307,9 @@ func (g *Client) runContentStream(ctx context.Context, ch chan<- llmshared.Strea
 		}
 	}
 }
-
 func (g *Client) streamGenerationStep(ctx context.Context, ch chan<- llmshared.StreamResult, modelName string, contents []*genai.Content, config *genai.GenerateContentConfig, handlers map[string]ai.HandlerFunc) (bool, []*genai.Content, error) {
 	stream := g.Client.Models.GenerateContentStream(ctx, modelName, contents, config)
 	var lastResp *genai.GenerateContentResponse
-
 	for resp, err := range stream {
 		if err != nil {
 			return true, nil, fmt.Errorf("error generating streamed content: %w", err)
@@ -386,34 +321,27 @@ func (g *Client) streamGenerationStep(ctx context.Context, ch chan<- llmshared.S
 			}
 		}
 	}
-
 	if err := ctx.Err(); err != nil {
 		return true, nil, err
 	}
-
 	if lastResp == nil {
 		return true, nil, fmt.Errorf("no response candidates")
 	}
-
 	if tc := g.publishUsageMetadata(lastResp.UsageMetadata); tc != nil {
 		if err := g.emitStreamChunk(ctx, ch, &ai.StreamChunk{TokenCount: tc}); err != nil {
 			return true, nil, err
 		}
 	}
-
 	fnCalls := lastResp.FunctionCalls()
 	if len(fnCalls) == 0 {
 		return true, nil, nil
 	}
-
 	updatedContents, err := g.handleFunctionCalls(ctx, lastResp, contents, handlers, false)
 	if err != nil {
 		return false, nil, err
 	}
-
 	return false, updatedContents, nil
 }
-
 func (g *Client) emitStreamChunk(ctx context.Context, ch chan<- llmshared.StreamResult, chunk *ai.StreamChunk) error {
 	if chunk == nil {
 		return nil
@@ -425,17 +353,14 @@ func (g *Client) emitStreamChunk(ctx context.Context, ch chan<- llmshared.Stream
 		return ctx.Err()
 	}
 }
-
 func (g *Client) responseToStreamChunk(resp *genai.GenerateContentResponse) *ai.StreamChunk {
 	if resp == nil || len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil {
 		return nil
 	}
-
 	chunk := &ai.StreamChunk{}
 	var textParts []string
 	var thoughtParts []string
 	showThoughts := g.Config.GetBoolWithDefault("GEMINI_SHOW_THOUGHTS", false)
-
 	for _, part := range resp.Candidates[0].Content.Parts {
 		switch {
 		case part.Text != "":
@@ -483,20 +408,17 @@ func (g *Client) responseToStreamChunk(resp *genai.GenerateContentResponse) *ai.
 			textParts = append(textParts, fmt.Sprintf("[model referenced file: %s]", part.FileData.FileURI))
 		}
 	}
-
 	if len(textParts) > 0 {
 		chunk.Text = strings.Join(textParts, "")
 	}
 	if len(thoughtParts) > 0 {
 		chunk.Thinking = strings.Join(thoughtParts, "")
 	}
-
 	if chunk.Text == "" && chunk.Thinking == "" && len(chunk.ToolCalls) == 0 {
 		return nil
 	}
 	return chunk
 }
-
 func (g *Client) convertFunctionCall(call *genai.FunctionCall) *ai.ToolCallChunk {
 	if call == nil {
 		return nil
@@ -511,14 +433,12 @@ func (g *Client) convertFunctionCall(call *genai.FunctionCall) *ai.ToolCallChunk
 		Parameters: parameters,
 	}
 }
-
 func normalizeToolIterations(value int32) int {
 	if value <= 0 {
 		return defaultMaxToolIterations
 	}
 	return int(value)
 }
-
 func buildGeminiImageContent(img *toolpayload.Payload) *genai.Content {
 	var parts []*genai.Part
 	if text := toolpayload.SanitizePath(img.Path); text != "" {
@@ -532,7 +452,6 @@ func buildGeminiImageContent(img *toolpayload.Payload) *genai.Content {
 	})
 	return genai.NewContentFromParts(parts, genai.RoleUser)
 }
-
 func buildGeminiDocumentContent(doc *toolpayload.Payload) *genai.Content {
 	parts := []*genai.Part{
 		genai.NewPartFromText(fmt.Sprintf("Document retrieved from %s (MIME: %s, %d bytes)", toolpayload.SanitizePath(doc.Path), doc.MIMEType, doc.SizeBytes)),
@@ -545,7 +464,6 @@ func buildGeminiDocumentContent(doc *toolpayload.Payload) *genai.Content {
 	}
 	return genai.NewContentFromParts(parts, genai.RoleUser)
 }
-
 func (g *Client) joinContentParts(content *genai.Content) string {
 	var (
 		textParts    []string
@@ -553,7 +471,6 @@ func (g *Client) joinContentParts(content *genai.Content) string {
 		extraParts   []string
 		showThoughts = g.Config.GetBoolWithDefault("GEMINI_SHOW_THOUGHTS", false)
 	)
-
 	for _, part := range content.Parts {
 		switch {
 		case part.Text != "":
@@ -569,7 +486,6 @@ func (g *Client) joinContentParts(content *genai.Content) string {
 			} else {
 				textParts = append(textParts, part.Text)
 			}
-
 		case part.FunctionResponse != nil && part.FunctionResponse.Response != nil:
 			payload, err := json.Marshal(part.FunctionResponse.Response)
 			if err != nil {
@@ -582,7 +498,6 @@ func (g *Client) joinContentParts(content *genai.Content) string {
 			} else {
 				extraParts = append(extraParts, fmt.Sprintf("%s: %s", label, string(payload)))
 			}
-
 		case part.FunctionCall != nil:
 			payload, err := json.Marshal(part.FunctionCall.Args)
 			if err != nil {
@@ -590,52 +505,41 @@ func (g *Client) joinContentParts(content *genai.Content) string {
 				continue
 			}
 			extraParts = append(extraParts, fmt.Sprintf("Function call %s(%s)", part.FunctionCall.Name, string(payload)))
-
 		case part.CodeExecutionResult != nil:
 			resultText := strings.TrimSpace(part.CodeExecutionResult.Output)
 			if resultText != "" {
 				extraParts = append(extraParts, resultText)
 			}
-
 		case part.ExecutableCode != nil:
 			code := strings.TrimSpace(part.ExecutableCode.Code)
 			if code != "" {
 				extraParts = append(extraParts, fmt.Sprintf("Executable code (%s):\n%s", part.ExecutableCode.Language, code))
 			}
-
 		case part.InlineData != nil && len(part.InlineData.Data) > 0:
 			extraParts = append(extraParts, fmt.Sprintf("[model returned %d bytes of %s data]", len(part.InlineData.Data), part.InlineData.MIMEType))
-
 		case part.FileData != nil && part.FileData.FileURI != "":
 			extraParts = append(extraParts, fmt.Sprintf("[model referenced file: %s]", part.FileData.FileURI))
 		}
 	}
-
 	if len(textParts) > 0 {
 		return strings.Join(textParts, "")
 	}
-
 	if len(extraParts) > 0 {
 		return strings.Join(extraParts, "\n")
 	}
-
 	if len(thoughtParts) > 0 {
 		return thoughtParts[len(thoughtParts)-1]
 	}
-
 	return ""
 }
-
 func (g *Client) invokeGenerateContent(ctx context.Context, modelName string, contents []*genai.Content, config *genai.GenerateContentConfig, handlers map[string]ai.HandlerFunc, maxIterations int) (result *genai.GenerateContentResponse, toolUsed bool, err error) {
 	return g.callGenerateContent(ctx, modelName, contents, config, handlers, maxIterations)
 }
-
 func (g *Client) countTokensWithPrompt(ctx context.Context, p ai.Prompt) (*ai.TokenCount, error) {
 	// Build the content parts for the user message
 	parts := []*genai.Part{
 		genai.NewPartFromText(p.Text),
 	}
-
 	// Add images if present
 	for _, img := range p.Images {
 		parts = append(parts, &genai.Part{
@@ -645,13 +549,10 @@ func (g *Client) countTokensWithPrompt(ctx context.Context, p ai.Prompt) (*ai.To
 			},
 		})
 	}
-
 	// Create the user content with proper role
 	userContent := genai.NewContentFromParts(parts, genai.RoleUser)
-
 	// Build contents array
 	var contents []*genai.Content
-
 	// Add system instruction as a separate content if provided
 	if p.Instruction != "" {
 		// System instructions are typically handled as user content in the unified API
@@ -661,32 +562,26 @@ func (g *Client) countTokensWithPrompt(ctx context.Context, p ai.Prompt) (*ai.To
 	} else {
 		contents = []*genai.Content{userContent}
 	}
-
 	// Use model name from prompt, or fallback to default
 	modelName := p.ModelName
 	if modelName == "" {
 		modelName = "gemini-2.0-flash" // Default model
 	}
-
 	// Count tokens using the Models.CountTokens method
 	countResp, err := g.Client.Models.CountTokens(ctx, modelName, contents, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error counting tokens: %w", err)
 	}
-
 	// Convert the response to our TokenCount type
 	tokenCount := &ai.TokenCount{
 		TotalTokens: countResp.TotalTokens,
 	}
-
 	// Check if the response has detailed token counts (may not be available in all backends)
 	if countResp.CachedContentTokenCount != 0 {
 		tokenCount.InputTokens = countResp.CachedContentTokenCount
 	}
-
 	return tokenCount, nil
 }
-
 // mapAttr converts a slice of Attr to a map
 func (g *Client) mapAttr(attrs []ai.Attr) map[string]string {
 	m := make(map[string]string)
@@ -695,7 +590,6 @@ func (g *Client) mapAttr(attrs []ai.Attr) map[string]string {
 	}
 	return m
 }
-
 // callGenerateContent executes the generation loop until the model returns a response without tool calls.
 func (g *Client) callGenerateContent(ctx context.Context, modelName string, contents []*genai.Content, config *genai.GenerateContentConfig, handlers map[string]ai.HandlerFunc, maxIterations int) (result *genai.GenerateContentResponse, toolUsed bool, err error) {
 	currentContents := make([]*genai.Content, len(contents))
@@ -706,12 +600,10 @@ func (g *Client) callGenerateContent(ctx context.Context, modelName string, cont
 		done            bool
 		stepUsedTool    bool
 	)
-
 	limit := maxIterations
 	if limit <= 0 {
 		limit = defaultMaxToolIterations
 	}
-
 	for iteration := 0; ; iteration++ {
 		result, updatedContents, done, stepUsedTool, err = g.executeGenerationStep(ctx, modelName, currentContents, currentConfig, handlers)
 		if err != nil {
@@ -727,7 +619,6 @@ func (g *Client) callGenerateContent(ctx context.Context, modelName string, cont
 		currentContents = updatedContents
 	}
 }
-
 func (g *Client) executeGenerationStep(ctx context.Context, modelName string, contents []*genai.Content, config *genai.GenerateContentConfig, handlers map[string]ai.HandlerFunc) (result *genai.GenerateContentResponse, updatedContents []*genai.Content, done bool, toolUsed bool, err error) {
 	if g.callGenerateContentFn != nil {
 		result, err = g.callGenerateContentFn(ctx, modelName, contents, config, handlers)
@@ -737,9 +628,7 @@ func (g *Client) executeGenerationStep(ctx context.Context, modelName string, co
 	if err != nil {
 		return nil, nil, false, false, fmt.Errorf("error generating content: %w", err)
 	}
-
 	g.publishUsageMetadata(result.UsageMetadata)
-
 	fnCalls := result.FunctionCalls()
 	if len(fnCalls) == 0 {
 		if len(result.Candidates) == 0 {
@@ -747,24 +636,19 @@ func (g *Client) executeGenerationStep(ctx context.Context, modelName string, co
 		}
 		return result, nil, true, false, nil
 	}
-
 	updatedContents, err = g.handleFunctionCalls(ctx, result, contents, handlers, true)
 	if err != nil {
 		return nil, nil, false, true, err
 	}
-
 	if config != nil {
 		config.ToolConfig = nil
 	}
-
 	return nil, updatedContents, false, true, nil
 }
-
 func (g *Client) publishUsageMetadata(usage *genai.GenerateContentResponseUsageMetadata) *ai.TokenCount {
 	if usage == nil {
 		return nil
 	}
-
 	tokenCountEvent := events.TokenCountEvent{
 		InputTokens:   usage.PromptTokenCount,
 		OutputTokens:  usage.CachedContentTokenCount,
@@ -773,7 +657,6 @@ func (g *Client) publishUsageMetadata(usage *genai.GenerateContentResponseUsageM
 		ToolUseTokens: usage.ToolUsePromptTokenCount,
 	}
 	g.EventBus.Publish(tokenCountEvent.Topic(), tokenCountEvent)
-
 	if g.Config.GetBoolWithDefault("GENIE_TOKEN_DEBUG", false) {
 		if usageMetadata, err := json.MarshalIndent(usage, "", "  "); err == nil {
 			notification := events.NotificationEvent{
@@ -782,19 +665,16 @@ func (g *Client) publishUsageMetadata(usage *genai.GenerateContentResponseUsageM
 			g.EventBus.Publish(notification.Topic(), notification)
 		}
 	}
-
 	return &ai.TokenCount{
 		TotalTokens:  usage.TotalTokenCount,
 		InputTokens:  usage.PromptTokenCount,
 		OutputTokens: usage.CachedContentTokenCount,
 	}
 }
-
 func (g *Client) handleFunctionCalls(ctx context.Context, result *genai.GenerateContentResponse, contents []*genai.Content, handlers map[string]ai.HandlerFunc, emitNotification bool) ([]*genai.Content, error) {
 	fnCalls := result.FunctionCalls()
 	updatedContents := make([]*genai.Content, len(contents))
 	copy(updatedContents, contents)
-
 	if len(result.Candidates) > 0 && result.Candidates[0].Content != nil {
 		if emitNotification {
 			contentStr := strings.TrimSpace(g.joinContentParts(result.Candidates[0].Content))
@@ -807,19 +687,16 @@ func (g *Client) handleFunctionCalls(ctx context.Context, result *genai.Generate
 		}
 		updatedContents = append(updatedContents, result.Candidates[0].Content)
 	}
-
 	responseContents := make([]*genai.Content, 0, len(fnCalls))
 	for _, fnCall := range fnCalls {
 		handler := handlers[fnCall.Name]
 		if handler == nil {
 			return nil, fmt.Errorf("no handler found for function %q", fnCall.Name)
 		}
-
 		handlerResp, err := handler(ctx, fnCall.Args)
 		if err != nil {
 			return nil, fmt.Errorf("error handling function %q: %w", fnCall.Name, err)
 		}
-
 		switch fnCall.Name {
 		case "viewImage":
 			img, sanitized, err := toolpayload.Extract(handlerResp)
@@ -840,13 +717,10 @@ func (g *Client) handleFunctionCalls(ctx context.Context, result *genai.Generate
 				updatedContents = append(updatedContents, buildGeminiDocumentContent(doc))
 			}
 		}
-
 		responseContents = append(responseContents, genai.NewContentFromFunctionResponse(fnCall.Name, handlerResp, roleTool))
 	}
-
 	if len(responseContents) > 0 {
 		updatedContents = append(updatedContents, responseContents...)
 	}
-
 	return updatedContents, nil
 }

--- a/pkg/llm/genai/helpers.go
+++ b/pkg/llm/genai/helpers.go
@@ -80,7 +80,18 @@ func (g *Client) buildGenerateConfig(p ai.Prompt) *genai.GenerateContentConfig {
 	}
 
 	includeThoughts := g.Config.GetBoolWithDefault("GEMINI_INCLUDE_THOUGHTS", false)
-	if includeThoughts {
+	isGemini3 := strings.Contains(strings.ToLower(p.ModelName), "gemini-3")
+
+	// Gemini 3 requires ThinkingLevel (cannot disable thinking)
+	// Gemini 2.5 uses ThinkingBudget
+	if isGemini3 {
+		thinkingLevel := genai.ThinkingLevel(g.Config.GetStringWithDefault("GEMINI_THINKING_LEVEL", "LOW"))
+		cfg.ThinkingConfig = &genai.ThinkingConfig{
+			ThinkingLevel:   thinkingLevel,
+			IncludeThoughts: includeThoughts,
+		}
+		used = true
+	} else if includeThoughts {
 		thinkingBudgetVal := int32(g.Config.GetIntWithDefault("GEMINI_THINKING_BUDGET", -1))
 		cfg.ThinkingConfig = &genai.ThinkingConfig{ThinkingBudget: &thinkingBudgetVal, IncludeThoughts: includeThoughts}
 		used = true

--- a/pkg/llm/multiplexer/client.go
+++ b/pkg/llm/multiplexer/client.go
@@ -99,6 +99,26 @@ func (c *Client) GenerateContentAttr(ctx context.Context, p ai.Prompt, debug boo
 	return client.GenerateContentAttr(ctx, p, debug, attrs)
 }
 
+// GenerateContentStream implements ai.Gen streaming by delegating to the selected provider.
+func (c *Client) GenerateContentStream(ctx context.Context, p ai.Prompt, debug bool, args ...string) (ai.Stream, error) {
+	client, provider, err := c.clientFor(p.LLMProvider)
+	if err != nil {
+		return nil, err
+	}
+	c.setLastContext(provider, p.ModelName)
+	return client.GenerateContentStream(ctx, p, debug, args...)
+}
+
+// GenerateContentAttrStream implements ai.Gen streaming with structured attributes.
+func (c *Client) GenerateContentAttrStream(ctx context.Context, p ai.Prompt, debug bool, attrs []ai.Attr) (ai.Stream, error) {
+	client, provider, err := c.clientFor(p.LLMProvider)
+	if err != nil {
+		return nil, err
+	}
+	c.setLastContext(provider, p.ModelName)
+	return client.GenerateContentAttrStream(ctx, p, debug, attrs)
+}
+
 // CountTokens implements ai.Gen by delegating to the selected provider.
 func (c *Client) CountTokens(ctx context.Context, p ai.Prompt, debug bool, args ...string) (*ai.TokenCount, error) {
 	client, provider, err := c.clientFor(p.LLMProvider)
@@ -131,15 +151,15 @@ func (c *Client) GetStatus() *ai.Status {
 			Message:   err.Error(),
 		}
 	}
- 	status := client.GetStatus()
- 	if status == nil {
- 		status = &ai.Status{}
- 	}
- 	status.Backend = provider
+	status := client.GetStatus()
+	if status == nil {
+		status = &ai.Status{}
+	}
+	status.Backend = provider
 	if model := c.getLastModel(); model != "" {
 		status.Model = fmt.Sprintf("%s (persona)", model)
 	}
- 	return status
+	return status
 }
 
 func (c *Client) clientFor(provider string) (ai.Gen, string, error) {
@@ -193,9 +213,9 @@ func (c *Client) canonicalizeProvider(provider string) (string, error) {
 func (c *Client) setLastContext(provider, model string) {
 	c.mu.Lock()
 	c.lastProvider = provider
- 	if trimmed := strings.TrimSpace(model); trimmed != "" {
- 		c.lastModel = trimmed
- 	}
+	if trimmed := strings.TrimSpace(model); trimmed != "" {
+		c.lastModel = trimmed
+	}
 	c.mu.Unlock()
 }
 

--- a/pkg/llm/multiplexer/client_test.go
+++ b/pkg/llm/multiplexer/client_test.go
@@ -25,6 +25,14 @@ func (f *fakeGen) GenerateContentAttr(ctx context.Context, p ai.Prompt, debug bo
 	return f.name, nil
 }
 
+func (f *fakeGen) GenerateContentStream(ctx context.Context, p ai.Prompt, debug bool, args ...string) (ai.Stream, error) {
+	return nil, nil
+}
+
+func (f *fakeGen) GenerateContentAttrStream(ctx context.Context, p ai.Prompt, debug bool, attrs []ai.Attr) (ai.Stream, error) {
+	return nil, nil
+}
+
 func (f *fakeGen) CountTokens(ctx context.Context, p ai.Prompt, debug bool, args ...string) (*ai.TokenCount, error) {
 	return &ai.TokenCount{TotalTokens: 1}, nil
 }

--- a/pkg/llm/ollama/client.go
+++ b/pkg/llm/ollama/client.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	defaultMaxToolIterations = 20
+	defaultMaxToolIterations = 200
 	defaultBaseURL           = "http://127.0.0.1:11434"
 	chatEndpoint             = "/api/chat"
 	tokenCountPredict        = 0

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	defaultMaxToolIterations = 20
+	defaultMaxToolIterations = 200
 	defaultSchemaName        = "response"
 )
 

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -12,13 +12,15 @@ import (
 
 	openai "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/packages/ssestream"
 	"github.com/openai/openai-go/shared"
+	openai_constant "github.com/openai/openai-go/shared/constant"
 
 	"github.com/kcaldas/genie/pkg/ai"
 	"github.com/kcaldas/genie/pkg/config"
 	"github.com/kcaldas/genie/pkg/events"
 	"github.com/kcaldas/genie/pkg/fileops"
-	sharedgenie "github.com/kcaldas/genie/pkg/llm/shared"
+	llmshared "github.com/kcaldas/genie/pkg/llm/shared"
 	"github.com/kcaldas/genie/pkg/llm/shared/toolpayload"
 	"github.com/kcaldas/genie/pkg/logging"
 	"github.com/kcaldas/genie/pkg/template"
@@ -36,6 +38,7 @@ var (
 
 type chatCompletionClient interface {
 	New(ctx context.Context, body openai.ChatCompletionNewParams, opts ...option.RequestOption) (*openai.ChatCompletion, error)
+	NewStreaming(ctx context.Context, body openai.ChatCompletionNewParams, opts ...option.RequestOption) *ssestream.Stream[openai.ChatCompletionChunk]
 }
 
 // Option configures the OpenAI client.
@@ -146,6 +149,24 @@ func (c *Client) GenerateContentAttr(ctx context.Context, prompt ai.Prompt, debu
 	}
 
 	return c.generateWithPrompt(ctx, *rendered)
+}
+
+func (c *Client) GenerateContentStream(ctx context.Context, prompt ai.Prompt, debug bool, args ...string) (ai.Stream, error) {
+	attrs := ai.StringsToAttr(args)
+	return c.GenerateContentAttrStream(ctx, prompt, debug, attrs)
+}
+
+func (c *Client) GenerateContentAttrStream(ctx context.Context, prompt ai.Prompt, debug bool, attrs []ai.Attr) (ai.Stream, error) {
+	if err := c.ensureInitialized(ctx); err != nil {
+		return nil, err
+	}
+
+	rendered, err := c.renderPrompt(prompt, debug, attrs)
+	if err != nil {
+		return nil, fmt.Errorf("rendering prompt: %w", err)
+	}
+
+	return c.generateWithPromptStream(ctx, *rendered)
 }
 
 // CountTokens renders the prompt, counts the estimated token usage with string attributes, and returns the result.
@@ -266,6 +287,281 @@ func (c *Client) generateWithPrompt(ctx context.Context, prompt ai.Prompt) (stri
 	c.applyGenerationConfig(&params, prompt)
 
 	return c.executeChat(ctx, params, prompt.Handlers, prompt.MaxToolIterations)
+}
+
+func (c *Client) generateWithPromptStream(ctx context.Context, prompt ai.Prompt) (ai.Stream, error) {
+	modelName := c.resolveModelName(prompt.ModelName)
+	messages, _, err := c.buildMessages(prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	params := openai.ChatCompletionNewParams{
+		Model:    shared.ChatModel(modelName),
+		Messages: messages,
+	}
+	c.applyGenerationConfig(&params, prompt)
+
+	streamCtx, cancel := context.WithCancel(ctx)
+	ch := make(chan llmshared.StreamResult, 1)
+
+	go c.runStreamingChat(streamCtx, ch, params, prompt.Handlers, prompt.MaxToolIterations)
+
+	return llmshared.NewChunkStream(cancel, ch), nil
+}
+
+func (c *Client) runStreamingChat(ctx context.Context, ch chan<- llmshared.StreamResult, baseParams openai.ChatCompletionNewParams, handlers map[string]ai.HandlerFunc, maxIterations int32) {
+	defer close(ch)
+
+	messages := append([]openai.ChatCompletionMessageParamUnion(nil), baseParams.Messages...)
+	params := baseParams
+
+	limit := int(maxIterations)
+	if limit <= 0 {
+		limit = defaultMaxToolIterations
+	}
+
+	for iteration := 0; iteration < limit; iteration++ {
+		params.Messages = messages
+
+		done, nextMessages, err := c.streamChatStep(ctx, ch, params, handlers)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			select {
+			case ch <- llmshared.StreamResult{Err: err}:
+			case <-ctx.Done():
+			}
+			return
+		}
+
+		if done {
+			return
+		}
+
+		messages = append(messages, nextMessages...)
+	}
+
+	select {
+	case ch <- llmshared.StreamResult{Err: fmt.Errorf("exceeded maximum tool call iterations (%d) without completion", limit)}:
+	case <-ctx.Done():
+	}
+}
+
+type toolCallState struct {
+	id        string
+	name      string
+	arguments strings.Builder
+}
+
+func (c *Client) streamChatStep(ctx context.Context, ch chan<- llmshared.StreamResult, params openai.ChatCompletionNewParams, handlers map[string]ai.HandlerFunc) (bool, []openai.ChatCompletionMessageParamUnion, error) {
+	stream := c.chatCompletions.NewStreaming(ctx, params)
+	defer stream.Close()
+
+	var assistantBuilder strings.Builder
+	toolStates := make(map[int64]*toolCallState)
+	toolOrder := make([]int64, 0, 2)
+	seenToolIndex := make(map[int64]bool)
+	var finishReason string
+	var lastUsage openai.CompletionUsage
+
+	for stream.Next() {
+		chunk := stream.Current()
+		if chunk.Usage.TotalTokens != 0 || chunk.Usage.PromptTokens != 0 || chunk.Usage.CompletionTokens != 0 {
+			lastUsage = chunk.Usage
+		}
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		choice := chunk.Choices[0]
+		if choice.Delta.Content != "" {
+			if err := c.emitStreamResult(ctx, ch, &ai.StreamChunk{Text: choice.Delta.Content}); err != nil {
+				return true, nil, err
+			}
+			assistantBuilder.WriteString(choice.Delta.Content)
+		}
+		if choice.Delta.FunctionCall.Name != "" || choice.Delta.FunctionCall.Arguments != "" {
+			index := int64(0)
+			state := toolStates[index]
+			if state == nil {
+				state = &toolCallState{}
+				toolStates[index] = state
+			}
+			if !seenToolIndex[index] {
+				toolOrder = append(toolOrder, index)
+				seenToolIndex[index] = true
+			}
+			if choice.Delta.FunctionCall.Name != "" {
+				state.name = choice.Delta.FunctionCall.Name
+			}
+			if choice.Delta.FunctionCall.Arguments != "" {
+				state.arguments.WriteString(choice.Delta.FunctionCall.Arguments)
+			}
+		}
+		if len(choice.Delta.ToolCalls) > 0 {
+			for _, tc := range choice.Delta.ToolCalls {
+				state := toolStates[tc.Index]
+				if state == nil {
+					state = &toolCallState{}
+					toolStates[tc.Index] = state
+				}
+				if !seenToolIndex[tc.Index] {
+					toolOrder = append(toolOrder, tc.Index)
+					seenToolIndex[tc.Index] = true
+				}
+				if tc.ID != "" {
+					state.id = tc.ID
+				}
+				if tc.Function.Name != "" {
+					state.name = tc.Function.Name
+				}
+				if tc.Function.Arguments != "" {
+					state.arguments.WriteString(tc.Function.Arguments)
+				}
+			}
+		}
+		if choice.FinishReason != "" {
+			finishReason = choice.FinishReason
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		return true, nil, fmt.Errorf("openai chat completion stream: %w", err)
+	}
+
+	if err := ctx.Err(); err != nil {
+		return true, nil, err
+	}
+
+	if lastUsage.TotalTokens != 0 || lastUsage.PromptTokens != 0 || lastUsage.CompletionTokens != 0 {
+		c.publishUsage(lastUsage)
+		if err := c.emitOpenAITokenChunk(ctx, ch, lastUsage); err != nil {
+			return true, nil, err
+		}
+	}
+
+	assistantParam := openai.ChatCompletionAssistantMessageParam{
+		Content: openai.ChatCompletionAssistantMessageParamContentUnion{
+			OfString: openai.String(assistantBuilder.String()),
+		},
+	}
+
+	var toolCalls []openai.ChatCompletionMessageToolCall
+	if len(toolStates) > 0 {
+		parsed, err := c.buildToolCalls(toolOrder, toolStates)
+		if err != nil {
+			return true, nil, err
+		}
+		toolCalls = parsed
+		assistantParam.ToolCalls = make([]openai.ChatCompletionMessageToolCallParam, len(parsed))
+		for i, call := range parsed {
+			assistantParam.ToolCalls[i] = call.ToParam()
+		}
+		if err := c.emitOpenAIToolChunk(ctx, ch, parsed); err != nil {
+			return true, nil, err
+		}
+	}
+
+	messages := []openai.ChatCompletionMessageParamUnion{
+		{OfAssistant: &assistantParam},
+	}
+
+	if len(toolCalls) == 0 {
+		if strings.TrimSpace(assistantBuilder.String()) == "" {
+			if finishReason == "" {
+				return true, nil, errors.New("openai returned an empty response")
+			}
+		}
+		return true, messages, nil
+	}
+
+	if len(handlers) == 0 {
+		return true, nil, fmt.Errorf("model requested %d tool calls but no handlers were provided", len(toolCalls))
+	}
+
+	toolMessages, err := c.executeToolCalls(ctx, toolCalls, handlers)
+	if err != nil {
+		return true, nil, err
+	}
+
+	messages = append(messages, toolMessages...)
+	return false, messages, nil
+}
+
+func (c *Client) buildToolCalls(order []int64, states map[int64]*toolCallState) ([]openai.ChatCompletionMessageToolCall, error) {
+	if len(states) == 0 {
+		return nil, nil
+	}
+
+	calls := make([]openai.ChatCompletionMessageToolCall, 0, len(states))
+	for _, idx := range order {
+		state := states[idx]
+		if state == nil {
+			continue
+		}
+		call := openai.ChatCompletionMessageToolCall{
+			ID: state.id,
+			Function: openai.ChatCompletionMessageToolCallFunction{
+				Name:      state.name,
+				Arguments: state.arguments.String(),
+			},
+			Type: openai_constant.Function("function"),
+		}
+		calls = append(calls, call)
+	}
+	return calls, nil
+}
+
+func (c *Client) emitStreamResult(ctx context.Context, ch chan<- llmshared.StreamResult, chunk *ai.StreamChunk) error {
+	if chunk == nil {
+		return nil
+	}
+	select {
+	case ch <- llmshared.StreamResult{Chunk: chunk}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *Client) emitOpenAITokenChunk(ctx context.Context, ch chan<- llmshared.StreamResult, usage openai.CompletionUsage) error {
+	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		return nil
+	}
+	chunk := &ai.StreamChunk{
+		TokenCount: &ai.TokenCount{
+			TotalTokens:  int32(usage.TotalTokens),
+			InputTokens:  int32(usage.PromptTokens),
+			OutputTokens: int32(usage.CompletionTokens),
+		},
+	}
+	return c.emitStreamResult(ctx, ch, chunk)
+}
+
+func (c *Client) emitOpenAIToolChunk(ctx context.Context, ch chan<- llmshared.StreamResult, calls []openai.ChatCompletionMessageToolCall) error {
+	if len(calls) == 0 {
+		return nil
+	}
+
+	toolChunks := make([]*ai.ToolCallChunk, 0, len(calls))
+	for _, call := range calls {
+		var params map[string]any
+		if strings.TrimSpace(call.Function.Arguments) != "" {
+			if err := json.Unmarshal([]byte(call.Function.Arguments), &params); err != nil {
+				params = map[string]any{
+					"raw": call.Function.Arguments,
+				}
+			}
+		}
+		toolChunks = append(toolChunks, &ai.ToolCallChunk{
+			ID:         call.ID,
+			Name:       call.Function.Name,
+			Parameters: params,
+		})
+	}
+
+	return c.emitStreamResult(ctx, ch, &ai.StreamChunk{ToolCalls: toolChunks})
 }
 
 func (c *Client) resolveModelName(promptModel string) string {
@@ -572,7 +868,7 @@ func buildDocumentUserMessage(doc *toolpayload.Payload) openai.ChatCompletionMes
 }
 
 func (c *Client) renderPrompt(prompt ai.Prompt, debug bool, attrs []ai.Attr) (*ai.Prompt, error) {
-	return sharedgenie.RenderPromptWithDebug(c.fileManager, prompt, debug, attrs)
+	return llmshared.RenderPromptWithDebug(c.fileManager, prompt, debug, attrs)
 }
 
 func (c *Client) publishUsage(usage openai.CompletionUsage) {

--- a/pkg/llm/openai/client_test.go
+++ b/pkg/llm/openai/client_test.go
@@ -9,6 +9,7 @@ import (
 
 	openai "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/packages/ssestream"
 	"github.com/openai/openai-go/shared"
 	"github.com/openai/openai-go/shared/constant"
 	"github.com/stretchr/testify/assert"
@@ -43,6 +44,10 @@ func (m *mockChatCompletions) New(ctx context.Context, params openai.ChatComplet
 	resp := m.responses[0]
 	m.responses = m.responses[1:]
 	return resp, nil
+}
+
+func (m *mockChatCompletions) NewStreaming(ctx context.Context, params openai.ChatCompletionNewParams, _ ...option.RequestOption) *ssestream.Stream[openai.ChatCompletionChunk] {
+	return nil
 }
 
 func newChatCompletionMessage(content string, toolCalls []openai.ChatCompletionMessageToolCall) openai.ChatCompletionChoice {

--- a/pkg/llm/shared/stream.go
+++ b/pkg/llm/shared/stream.go
@@ -1,0 +1,79 @@
+package shared
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/kcaldas/genie/pkg/ai"
+)
+
+// StreamResult represents a single item emitted by a streaming provider.
+// Exactly one of Chunk or Err should be set.
+type StreamResult struct {
+	Chunk *ai.StreamChunk
+	Err   error
+}
+
+// NewChunkStream wraps a channel of StreamResult values and exposes it as an ai.Stream.
+// The provided cancel function is called when the stream is closed to allow callers
+// to stop upstream work early.
+func NewChunkStream(cancel context.CancelFunc, ch <-chan StreamResult) ai.Stream {
+	return &chunkStream{
+		cancel: cancel,
+		ch:     ch,
+	}
+}
+
+type chunkStream struct {
+	cancel context.CancelFunc
+
+	mu     sync.Mutex
+	ch     <-chan StreamResult
+	closed bool
+}
+
+func (s *chunkStream) Recv() (*ai.StreamChunk, error) {
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return nil, io.EOF
+	}
+
+	result, ok := <-s.ch
+	if !ok {
+		s.mu.Lock()
+		s.closed = true
+		s.mu.Unlock()
+		return nil, io.EOF
+	}
+
+	if result.Err != nil {
+		s.Close()
+		return nil, result.Err
+	}
+
+	if result.Chunk == nil {
+		return nil, nil
+	}
+	return result.Chunk, nil
+}
+
+func (s *chunkStream) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	s.mu.Unlock()
+
+	if s.cancel != nil {
+		s.cancel()
+	}
+	// Drain any remaining results to allow the producer goroutine to exit.
+	for range s.ch {
+	}
+	return nil
+}

--- a/pkg/prompts/loader_test.go
+++ b/pkg/prompts/loader_test.go
@@ -29,6 +29,18 @@ func (m *MockGen) GenerateContentAttr(ctx context.Context, prompt ai.Prompt, deb
 	return arguments.String(0), arguments.Error(1)
 }
 
+func (m *MockGen) GenerateContentStream(ctx context.Context, prompt ai.Prompt, debug bool, args ...string) (ai.Stream, error) {
+	arguments := m.Called(ctx, prompt, debug, args)
+	stream, _ := arguments.Get(0).(ai.Stream)
+	return stream, arguments.Error(1)
+}
+
+func (m *MockGen) GenerateContentAttrStream(ctx context.Context, prompt ai.Prompt, debug bool, attrs []ai.Attr) (ai.Stream, error) {
+	arguments := m.Called(ctx, prompt, debug, attrs)
+	stream, _ := arguments.Get(0).(ai.Stream)
+	return stream, arguments.Error(1)
+}
+
 // MockLoader implements Loader for testing
 type MockLoader struct {
 	LoadCount int // Track how many times LoadPromptFromFS is called


### PR DESCRIPTION
## Summary
- Implement streaming support for LLM responses with incremental chunk delivery
- Fix Gemini 3 compatibility by using `ThinkingLevel` config instead of `ThinkingBudget`
- Accumulate parts across all stream chunks to properly detect function calls
- Filter empty parts to prevent API errors on conversation continuation
- Add `FinishReason` checking for better error reporting on blocked responses

## Test plan
- [x] Verify streaming works with Gemini 2.5 and Gemini 3 models
- [x] Verify function calls (including `thinking` tool) handled during streaming
- [x] Verify `chat.chunk` and `chat.response` events emitted correctly