### PR TITLE
Add LM Studio support and stabilize streaming

### DIFF
--- a/.genie/personas/alfredo/prompt.yaml
+++ b/.genie/personas/alfredo/prompt.yaml
@@ -1,0 +1,33 @@
+name: "Alfredo"
+llm_provider: lmstudio
+model_name: gpt-oss-20b
+max_tokens: 1000
+temperature: 0.2
+top_p: 0.9
+max_tool_iterations: 10
+required_tools:
+  - "@essentials"
+  - "@memory"
+  - "listFiles"
+  - "findFiles"
+  - "readFile"
+  - "searchInFiles"
+  - "writeFile"
+  - "bash"
+  - "viewImage"
+text: |
+  {{- if .chat }}
+  ## Conversation History
+  {{ .chat }}
+  {{ end -}}
+
+  ## User Message
+  {{ .message }}
+instruction: |
+  You are Alfredo, the LM Studio exercise persona.
+
+  - Keep replies short and pragmatic; prefer bullet lists or one-liners unless detail is requested.
+  - Your goal is to validate the LM Studio integration: call tools when helpful, note any unexpected latency or partial outputs, and suggest simple follow-up checks the user can run.
+  - When using tools, mention what you are about to inspect before running them.
+  - If you need a model hint, default to the configured LM Studio model name but avoid guessing capabilities.
+  - Highlight any streaming or tool-call quirks you observe so they can be debugged quickly.

--- a/.genie/personas/alfredo/prompt.yaml
+++ b/.genie/personas/alfredo/prompt.yaml
@@ -4,7 +4,7 @@ model_name: gpt-oss-20b
 max_tokens: 1000
 temperature: 0.2
 top_p: 0.9
-max_tool_iterations: 10
+max_tool_iterations: 100
 required_tools:
   - "@essentials"
   - "@memory"

--- a/.genie/personas/gepeto/prompt.yaml
+++ b/.genie/personas/gepeto/prompt.yaml
@@ -1,7 +1,7 @@
 name: "Gepeto"
 llm_provider: openai
 model_name: gpt-5
-max_tool_iterations: 20
+max_tool_iterations: 200
 temperature: 1.0
 required_tools:
   - "@essentials"

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ coverage.out
 *.tmp
 *.temp
 *.log
+.gocache

--- a/pkg/events/bus.go
+++ b/pkg/events/bus.go
@@ -3,7 +3,10 @@ package events
 import (
 	"log"
 	"sync"
+	"sync/atomic"
 )
+
+const defaultTopicBuffer = 256
 
 // EventHandler is a function that handles an event
 type EventHandler func(event interface{})
@@ -28,16 +31,30 @@ type EventBus interface {
 type InMemoryBus struct {
 	mu          sync.RWMutex
 	subscribers map[string][]EventHandler
+	workers     map[string]*topicWorker
+	bufferSize  int
+	dropped     atomic.Int64
 }
 
-// NewEventBus creates a new event bus
+// NewEventBus creates a new event bus with the default buffer size.
 func NewEventBus() EventBus {
+	return NewEventBusWithBuffer(defaultTopicBuffer)
+}
+
+// NewEventBusWithBuffer allows configuring the per-topic worker queue size.
+// A buffer of at least 1 is enforced to avoid unbuffered sends.
+func NewEventBusWithBuffer(buffer int) EventBus {
+	if buffer < 1 {
+		buffer = 1
+	}
 	return &InMemoryBus{
 		subscribers: make(map[string][]EventHandler),
+		workers:     make(map[string]*topicWorker),
+		bufferSize:  buffer,
 	}
 }
 
-// Subscribe adds a handler for a specific event type
+// Subscribe adds a handler for a specific event type.
 func (b *InMemoryBus) Subscribe(eventType string, handler EventHandler) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -45,22 +62,106 @@ func (b *InMemoryBus) Subscribe(eventType string, handler EventHandler) {
 	b.subscribers[eventType] = append(b.subscribers[eventType], handler)
 }
 
-// Publish sends an event to all subscribers of that event type
+// Publish sends an event to all subscribers of that event type.
+// Events are delivered in-order per topic via a dedicated worker goroutine.
+// Publishing is non-blocking: if the queue is full, the event is dropped.
 func (b *InMemoryBus) Publish(eventType string, event interface{}) {
+	handlers := b.handlersFor(eventType)
+	if len(handlers) == 0 {
+		return
+	}
+
+	worker := b.getOrCreateWorker(eventType)
+	env := eventEnvelope{
+		event:    event,
+		handlers: handlers,
+	}
+
+	select {
+	case worker.ch <- env:
+	default:
+		// Preserve non-blocking semantics; drop if the topic queue is full.
+		b.dropped.Add(1)
+		log.Printf("Event bus queue full for topic %s; dropping event", eventType)
+	}
+}
+
+// DroppedCount returns the number of events dropped due to full queues.
+func (b *InMemoryBus) DroppedCount() int64 {
+	return b.dropped.Load()
+}
+
+// Shutdown stops all topic workers. Primarily useful for tests.
+func (b *InMemoryBus) Shutdown() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, w := range b.workers {
+		w.stop()
+	}
+}
+
+// handlersFor snapshots handlers for the topic.
+func (b *InMemoryBus) handlersFor(eventType string) []EventHandler {
 	b.mu.RLock()
+	defer b.mu.RUnlock()
 	handlers := make([]EventHandler, len(b.subscribers[eventType]))
 	copy(handlers, b.subscribers[eventType])
-	b.mu.RUnlock()
+	return handlers
+}
 
-	// Call all handlers asynchronously with panic recovery
-	for _, handler := range handlers {
-		go func(h EventHandler, e interface{}) {
-			defer func() {
-				if r := recover(); r != nil {
-					log.Printf("Event handler panicked: %v", r)
-				}
-			}()
-			h(e)
-		}(handler, event)
+// getOrCreateWorker returns the per-topic worker, creating it if needed.
+func (b *InMemoryBus) getOrCreateWorker(eventType string) *topicWorker {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if worker, ok := b.workers[eventType]; ok {
+		return worker
 	}
+
+	worker := newTopicWorker(b.bufferSize)
+	b.workers[eventType] = worker
+	return worker
+}
+
+type eventEnvelope struct {
+	event    interface{}
+	handlers []EventHandler
+}
+
+type topicWorker struct {
+	ch       chan eventEnvelope
+	wg       sync.WaitGroup
+	stopOnce sync.Once
+}
+
+func newTopicWorker(buffer int) *topicWorker {
+	w := &topicWorker{
+		ch: make(chan eventEnvelope, buffer),
+	}
+	w.wg.Add(1)
+	go w.run()
+	return w
+}
+
+func (w *topicWorker) run() {
+	defer w.wg.Done()
+	for env := range w.ch {
+		for _, handler := range env.handlers {
+			func(h EventHandler, e interface{}) {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("Event handler panicked: %v", r)
+					}
+				}()
+				h(e)
+			}(handler, env.event)
+		}
+	}
+}
+
+func (w *topicWorker) stop() {
+	w.stopOnce.Do(func() {
+		close(w.ch)
+		w.wg.Wait()
+	})
 }

--- a/pkg/genie/wire.go
+++ b/pkg/genie/wire.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kcaldas/genie/pkg/events"
 	"github.com/kcaldas/genie/pkg/llm/anthropic"
 	"github.com/kcaldas/genie/pkg/llm/genai"
+	"github.com/kcaldas/genie/pkg/llm/lmstudio"
 	"github.com/kcaldas/genie/pkg/llm/multiplexer"
 	"github.com/kcaldas/genie/pkg/llm/ollama"
 	"github.com/kcaldas/genie/pkg/llm/openai"
@@ -210,6 +211,7 @@ func ProvideAIGenWithCapture(configManager config.Manager) (ai.Gen, error) {
 		"openai":    func() (ai.Gen, error) { return openai.NewClient(eventBus) },
 		"anthropic": func() (ai.Gen, error) { return anthropic.NewClient(eventBus) },
 		"ollama":    func() (ai.Gen, error) { return ollama.NewClient(eventBus) },
+		"lmstudio":  func() (ai.Gen, error) { return lmstudio.NewClient(eventBus) },
 	}
 
 	aliases := map[string]string{
@@ -219,6 +221,7 @@ func ProvideAIGenWithCapture(configManager config.Manager) (ai.Gen, error) {
 		"openai-chat":      "openai",
 		"claude":           "anthropic",
 		"anthropic-claude": "anthropic",
+		"lm-studio":        "lmstudio",
 	}
 
 	muxClient, err := multiplexer.NewClient(provider, factories, aliases)

--- a/pkg/genie/wire_gen.go
+++ b/pkg/genie/wire_gen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kcaldas/genie/pkg/events"
 	"github.com/kcaldas/genie/pkg/llm/anthropic"
 	"github.com/kcaldas/genie/pkg/llm/genai"
+	"github.com/kcaldas/genie/pkg/llm/lmstudio"
 	"github.com/kcaldas/genie/pkg/llm/multiplexer"
 	"github.com/kcaldas/genie/pkg/llm/ollama"
 	"github.com/kcaldas/genie/pkg/llm/openai"
@@ -344,6 +345,7 @@ func ProvideAIGenWithCapture(configManager config.Manager) (ai.Gen, error) {
 		"openai":    func() (ai.Gen, error) { return openai.NewClient(eventBus) },
 		"anthropic": func() (ai.Gen, error) { return anthropic.NewClient(eventBus) },
 		"ollama":    func() (ai.Gen, error) { return ollama.NewClient(eventBus) },
+		"lmstudio":  func() (ai.Gen, error) { return lmstudio.NewClient(eventBus) },
 	}
 
 	aliases := map[string]string{
@@ -353,6 +355,7 @@ func ProvideAIGenWithCapture(configManager config.Manager) (ai.Gen, error) {
 		"openai-chat":      "openai",
 		"claude":           "anthropic",
 		"anthropic-claude": "anthropic",
+		"lm-studio":        "lmstudio",
 	}
 
 	muxClient, err := multiplexer.NewClient(provider, factories, aliases)

--- a/pkg/llm/lmstudio/client.go
+++ b/pkg/llm/lmstudio/client.go
@@ -1,0 +1,906 @@
+package lmstudio
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kcaldas/genie/pkg/ai"
+	"github.com/kcaldas/genie/pkg/config"
+	"github.com/kcaldas/genie/pkg/events"
+	"github.com/kcaldas/genie/pkg/fileops"
+	llmshared "github.com/kcaldas/genie/pkg/llm/shared"
+	"github.com/kcaldas/genie/pkg/llm/shared/toolpayload"
+	"github.com/kcaldas/genie/pkg/logging"
+	"github.com/kcaldas/genie/pkg/template"
+)
+
+const (
+	defaultMaxToolIterations = 200
+	defaultBaseURL           = "http://127.0.0.1:1234"
+	chatEndpoint             = "/chat/completions"
+)
+
+var (
+	errEmptyResponse     = errors.New("lm studio returned an empty response")
+	errToolCallNoHandler = errors.New("model requested tool calls but no handlers were provided")
+
+	_ ai.Gen = (*Client)(nil)
+)
+
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Option configures the LM Studio client.
+type Option func(*Client)
+
+// WithConfigManager injects a custom configuration manager.
+func WithConfigManager(manager config.Manager) Option {
+	return func(c *Client) {
+		if manager != nil {
+			c.config = manager
+		}
+	}
+}
+
+// WithFileManager injects a custom file manager (useful for tests).
+func WithFileManager(manager fileops.Manager) Option {
+	return func(c *Client) {
+		if manager != nil {
+			c.fileManager = manager
+		}
+	}
+}
+
+// WithTemplateEngine injects a custom template engine.
+func WithTemplateEngine(engine template.Engine) Option {
+	return func(c *Client) {
+		if engine != nil {
+			c.template = engine
+		}
+	}
+}
+
+// WithLogger injects a custom logger implementation.
+func WithLogger(logger logging.Logger) Option {
+	return func(c *Client) {
+		if logger != nil {
+			c.logger = logger
+		}
+	}
+}
+
+// WithHTTPClient injects a custom HTTP client.
+func WithHTTPClient(client httpDoer) Option {
+	return func(c *Client) {
+		if client != nil {
+			c.httpClient = client
+		}
+	}
+}
+
+// WithBaseURL overrides the LM Studio base URL.
+func WithBaseURL(baseURL string) Option {
+	return func(c *Client) {
+		if strings.TrimSpace(baseURL) != "" {
+			c.baseURL = ensureV1Suffix(baseURL)
+		}
+	}
+}
+
+// Client provides an ai.Gen implementation backed by the LM Studio REST API.
+type Client struct {
+	mu sync.Mutex
+
+	config      config.Manager
+	fileManager fileops.Manager
+	template    template.Engine
+	eventBus    events.EventBus
+	logger      logging.Logger
+
+	httpClient httpDoer
+	baseURL    string
+}
+
+// NewClient creates a new LM Studio-backed ai.Gen implementation.
+func NewClient(eventBus events.EventBus, opts ...Option) (ai.Gen, error) {
+	client := &Client{
+		config:      config.NewConfigManager(),
+		fileManager: fileops.NewFileOpsManager(),
+		template:    template.NewEngine(),
+		eventBus:    eventBus,
+		logger:      logging.NewAPILogger("lmstudio"),
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+
+	if client.eventBus == nil {
+		client.eventBus = &events.NoOpEventBus{}
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	if client.logger == nil {
+		client.logger = logging.NewAPILogger("lmstudio")
+	}
+
+	if strings.TrimSpace(client.baseURL) == "" {
+		client.baseURL = client.resolveBaseURL()
+	}
+
+	if strings.TrimSpace(client.baseURL) == "" {
+		return nil, errors.New("lm studio base URL not configured")
+	}
+
+	return client, nil
+}
+
+// GenerateContent renders the prompt using string attributes and executes it.
+func (c *Client) GenerateContent(ctx context.Context, prompt ai.Prompt, debug bool, args ...string) (string, error) {
+	attrs := ai.StringsToAttr(args)
+	return c.GenerateContentAttr(ctx, prompt, debug, attrs)
+}
+
+// GenerateContentAttr renders the prompt using structured attributes and executes it.
+func (c *Client) GenerateContentAttr(ctx context.Context, prompt ai.Prompt, debug bool, attrs []ai.Attr) (string, error) {
+	rendered, err := c.renderPrompt(prompt, debug, attrs)
+	if err != nil {
+		return "", fmt.Errorf("rendering prompt: %w", err)
+	}
+
+	return c.generateWithPrompt(ctx, *rendered)
+}
+
+// GenerateContentStream renders the prompt using string attributes and executes it with streaming.
+func (c *Client) GenerateContentStream(ctx context.Context, prompt ai.Prompt, debug bool, args ...string) (ai.Stream, error) {
+	attrs := ai.StringsToAttr(args)
+	return c.GenerateContentAttrStream(ctx, prompt, debug, attrs)
+}
+
+// GenerateContentAttrStream renders the prompt using structured attributes and executes it with streaming.
+func (c *Client) GenerateContentAttrStream(ctx context.Context, prompt ai.Prompt, debug bool, attrs []ai.Attr) (ai.Stream, error) {
+	rendered, err := c.renderPrompt(prompt, debug, attrs)
+	if err != nil {
+		return nil, fmt.Errorf("rendering prompt: %w", err)
+	}
+
+	// If tools are involved, fall back to the non-streaming tool-execution flow and wrap the result as a stream.
+	if len(rendered.Functions) > 0 && len(rendered.Handlers) > 0 {
+		streamCtx, cancel := context.WithCancel(ctx)
+		ch := make(chan llmshared.StreamResult, 1)
+
+		go func() {
+			defer close(ch)
+			resp, err := c.GenerateContentAttr(streamCtx, *rendered, debug, nil)
+			if err != nil {
+				select {
+				case ch <- llmshared.StreamResult{Err: err}:
+				case <-streamCtx.Done():
+				}
+				return
+			}
+			select {
+			case ch <- llmshared.StreamResult{Chunk: &ai.StreamChunk{Text: resp}}:
+			case <-streamCtx.Done():
+			}
+		}()
+
+		return llmshared.NewChunkStream(cancel, ch), nil
+	}
+
+	request, err := c.buildChatRequest(*rendered, normalMode)
+	if err != nil {
+		return nil, err
+	}
+
+	streamCtx, cancel := context.WithCancel(ctx)
+	ch := make(chan llmshared.StreamResult, 1)
+
+	go c.runStreamingChat(streamCtx, ch, request)
+
+	return llmshared.NewChunkStream(cancel, ch), nil
+}
+
+// CountTokens renders the prompt, estimates token usage using string attributes, and returns the result.
+func (c *Client) CountTokens(ctx context.Context, prompt ai.Prompt, debug bool, args ...string) (*ai.TokenCount, error) {
+	attrs := ai.StringsToAttr(args)
+	return c.CountTokensAttr(ctx, prompt, debug, attrs)
+}
+
+// CountTokensAttr renders the prompt, estimates token usage using structured attributes, and returns the result.
+func (c *Client) CountTokensAttr(ctx context.Context, prompt ai.Prompt, debug bool, attrs []ai.Attr) (*ai.TokenCount, error) {
+	rendered, err := c.renderPrompt(prompt, debug, attrs)
+	if err != nil {
+		return nil, fmt.Errorf("rendering prompt: %w", err)
+	}
+
+	request, err := c.buildChatRequest(*rendered, countTokensMode)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := c.sendChat(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenCount := c.buildTokenCount(response.Usage)
+	c.publishTokenCount(tokenCount)
+
+	return tokenCount, nil
+}
+
+// GetStatus reports the configured model and target endpoint.
+func (c *Client) GetStatus() *ai.Status {
+	model := c.config.GetModelConfig()
+	modelStr := fmt.Sprintf("%s, Temperature: %.2f, Max Tokens: %d", model.ModelName, model.Temperature, model.MaxTokens)
+
+	message := fmt.Sprintf("LM Studio configured (endpoint: %s)", c.baseURL)
+	return &ai.Status{
+		Model:     modelStr,
+		Backend:   "lmstudio",
+		Connected: true,
+		Message:   message,
+	}
+}
+
+func (c *Client) generateWithPrompt(ctx context.Context, prompt ai.Prompt) (string, error) {
+	request, err := c.buildChatRequest(prompt, normalMode)
+	if err != nil {
+		return "", err
+	}
+
+	messages := append([]chatMessage(nil), request.Messages...)
+	toolUsed := false
+
+	limit := int(prompt.MaxToolIterations)
+	if limit <= 0 {
+		limit = defaultMaxToolIterations
+	}
+
+	for iteration := 0; iteration < limit; iteration++ {
+		request.Messages = messages
+
+		response, err := c.sendChat(ctx, request)
+		if err != nil {
+			return "", err
+		}
+
+		c.publishTokenCount(c.buildTokenCount(response.Usage))
+
+		if len(response.Choices) == 0 {
+			return "", errEmptyResponse
+		}
+		assistant := response.Choices[0].Message
+		assistantContent := strings.TrimSpace(assistant.Content.Text())
+		hasToolCalls := len(assistant.ToolCalls) > 0
+		if hasToolCalls {
+			toolUsed = true
+		}
+
+		if hasToolCalls && assistantContent != "" {
+			notification := events.NotificationEvent{Message: assistantContent}
+			c.eventBus.Publish(notification.Topic(), notification)
+		}
+
+		messages = append(messages, assistant.toChatMessage())
+
+		if !hasToolCalls {
+			if assistantContent == "" {
+				if toolUsed {
+					return "", nil
+				}
+				return "", errEmptyResponse
+			}
+			return assistantContent, nil
+		}
+
+		if len(prompt.Handlers) == 0 {
+			return "", errToolCallNoHandler
+		}
+
+		toolMessages, err := c.executeToolCalls(ctx, assistant.ToolCalls, prompt.Handlers)
+		if err != nil {
+			return "", err
+		}
+		messages = append(messages, toolMessages...)
+	}
+
+	return "", fmt.Errorf("exceeded maximum tool call iterations (%d) without completion", limit)
+}
+
+func (c *Client) executeToolCalls(ctx context.Context, calls []toolCall, handlers map[string]ai.HandlerFunc) ([]chatMessage, error) {
+	messages := make([]chatMessage, 0, len(calls))
+
+	for _, call := range calls {
+		handler := handlers[call.Function.Name]
+		if handler == nil {
+			return nil, fmt.Errorf("no handler registered for function %q", call.Function.Name)
+		}
+
+		args, err := call.Function.ArgumentsAsMap()
+		if err != nil {
+			return nil, fmt.Errorf("invalid arguments for function %q: %w", call.Function.Name, err)
+		}
+
+		result, err := handler(ctx, args)
+		if err != nil {
+			return nil, fmt.Errorf("handler for function %q failed: %w", call.Function.Name, err)
+		}
+
+		if call.Function.Name == "viewImage" {
+			img, sanitized, err := toolpayload.Extract(result)
+			if err != nil {
+				return nil, fmt.Errorf("invalid viewImage response: %w", err)
+			}
+			result = sanitized
+
+			payload, err := json.Marshal(result)
+			if err != nil {
+				return nil, fmt.Errorf("unable to marshal response for function %q: %w", call.Function.Name, err)
+			}
+
+			messages = append(messages, chatMessage{
+				Role:       "tool",
+				Content:    newMessageContentFromText(string(payload)),
+				ToolCallID: call.ID,
+			})
+
+			if img != nil {
+				messages = append(messages, buildImageUserMessage(img))
+			}
+			continue
+		}
+
+		if call.Function.Name == "viewDocument" {
+			doc, sanitized, err := toolpayload.Extract(result)
+			if err != nil {
+				return nil, fmt.Errorf("invalid viewDocument response: %w", err)
+			}
+			result = sanitized
+
+			payload, err := json.Marshal(result)
+			if err != nil {
+				return nil, fmt.Errorf("unable to marshal response for function %q: %w", call.Function.Name, err)
+			}
+
+			messages = append(messages, chatMessage{
+				Role:       "tool",
+				Content:    newMessageContentFromText(string(payload)),
+				ToolCallID: call.ID,
+			})
+
+			if doc != nil {
+				messages = append(messages, buildDocumentUserMessage(doc))
+			}
+			continue
+		}
+
+		payload, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("unable to marshal response for function %q: %w", call.Function.Name, err)
+		}
+
+		messages = append(messages, chatMessage{
+			Role:       "tool",
+			Content:    newMessageContentFromText(string(payload)),
+			ToolCallID: call.ID,
+		})
+	}
+
+	return messages, nil
+}
+
+func buildImageUserMessage(img *toolpayload.Payload) chatMessage {
+	text := toolpayload.SanitizePath(img.Path)
+	parts := []contentPart{
+		{Type: "text", Text: fmt.Sprintf("Image retrieved from %s", text)},
+		{Type: "image_url", ImageURL: &imageURL{URL: img.DataURL()}},
+	}
+	return chatMessage{
+		Role:    "user",
+		Content: newMessageContent(parts),
+	}
+}
+
+func buildDocumentUserMessage(doc *toolpayload.Payload) chatMessage {
+	parts := []contentPart{
+		{Type: "text", Text: fmt.Sprintf("Document retrieved from %s (MIME: %s, %d bytes).", toolpayload.SanitizePath(doc.Path), doc.MIMEType, doc.SizeBytes)},
+		{Type: "text", Text: "Inline document attachments are not supported; see tool response."},
+	}
+	return chatMessage{
+		Role:    "user",
+		Content: newMessageContent(parts),
+	}
+}
+
+func (c *Client) buildChatRequest(prompt ai.Prompt, mode requestMode) (chatRequest, error) {
+	modelName := c.resolveModelName(prompt.ModelName)
+	if strings.TrimSpace(modelName) == "" {
+		return chatRequest{}, errors.New("no LM Studio model configured")
+	}
+
+	messages := c.buildMessages(prompt)
+
+	req := chatRequest{
+		Model:    modelName,
+		Messages: messages,
+		Stream:   false,
+	}
+
+	c.applyGenerationConfig(&req, prompt, mode)
+
+	if len(prompt.Functions) > 0 {
+		req.Tools = mapFunctions(prompt.Functions)
+		if len(req.Tools) > 0 {
+			auto := "auto"
+			req.ToolChoice = &auto
+		}
+	}
+
+	if prompt.ResponseSchema != nil {
+		format, err := schemaToResponseFormat(prompt)
+		if err != nil {
+			return chatRequest{}, err
+		}
+		req.ResponseFormat = format
+	}
+
+	return req, nil
+}
+
+func (c *Client) buildMessages(prompt ai.Prompt) []chatMessage {
+	var messages []chatMessage
+
+	if instruction := strings.TrimSpace(prompt.Instruction); instruction != "" {
+		messages = append(messages, chatMessage{
+			Role:    "system",
+			Content: newMessageContentFromText(instruction),
+		})
+	}
+
+	if prompt.ResponseSchema != nil && strings.TrimSpace(prompt.Instruction) == "" {
+		schemaJSON, err := schemaToJSON(prompt.ResponseSchema)
+		if err == nil && strings.TrimSpace(schemaJSON) != "" {
+			instruction := fmt.Sprintf("You must respond with JSON matching this schema:\n%s", schemaJSON)
+			messages = append(messages, chatMessage{
+				Role:    "system",
+				Content: newMessageContentFromText(instruction),
+			})
+		}
+	}
+
+	userMessage := c.buildUserMessage(prompt)
+	messages = append(messages, userMessage)
+
+	return messages
+}
+
+func (c *Client) buildUserMessage(prompt ai.Prompt) chatMessage {
+	text := strings.TrimSpace(prompt.Text)
+	var parts []contentPart
+
+	if text != "" {
+		parts = append(parts, contentPart{Type: "text", Text: text})
+	}
+
+	for _, img := range prompt.Images {
+		if img == nil || len(img.Data) == 0 {
+			continue
+		}
+		dataURL := c.encodeImage(img)
+		if dataURL == "" {
+			continue
+		}
+		parts = append(parts, contentPart{
+			Type:     "image_url",
+			ImageURL: &imageURL{URL: dataURL},
+		})
+	}
+
+	if len(parts) == 0 {
+		return chatMessage{
+			Role:    "user",
+			Content: newMessageContentFromText(""),
+		}
+	}
+
+	if len(parts) == 1 && parts[0].Type == "text" {
+		return chatMessage{
+			Role:    "user",
+			Content: newMessageContentFromText(parts[0].Text),
+		}
+	}
+
+	return chatMessage{
+		Role:    "user",
+		Content: newMessageContent(parts),
+	}
+}
+
+func (c *Client) applyGenerationConfig(req *chatRequest, prompt ai.Prompt, mode requestMode) {
+	modelCfg := c.config.GetModelConfig()
+
+	maxTokens := prompt.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = modelCfg.MaxTokens
+	}
+	if mode == countTokensMode {
+		maxTokens = 0
+	}
+	if maxTokens > 0 || mode == countTokensMode {
+		value := int32(maxTokens)
+		req.MaxTokens = &value
+	}
+
+	temperature := prompt.Temperature
+	if temperature <= 0 {
+		temperature = modelCfg.Temperature
+	}
+	if temperature > 0 {
+		value := float32(temperature)
+		req.Temperature = &value
+	}
+
+	topP := prompt.TopP
+	if topP <= 0 {
+		topP = modelCfg.TopP
+	}
+	if topP > 0 && topP < 1.0 {
+		value := float32(topP)
+		req.TopP = &value
+	}
+}
+
+func (c *Client) sendChat(ctx context.Context, req chatRequest) (*chatResponse, error) {
+	req.Stream = false
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := c.baseURL + chatEndpoint
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	c.logger.Debug("lmstudio request", "url", url, "body", string(payload))
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	for key, values := range ai.DefaultHTTPHeaders() {
+		for _, value := range values {
+			httpReq.Header.Add(key, value)
+		}
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("lm studio chat request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading lm studio response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("lm studio chat request failed: status %s: %s", resp.Status, string(body))
+	}
+
+	var response chatResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("decoding lm studio response: %w", err)
+	}
+
+	c.logger.Debug("lmstudio response", "status", resp.StatusCode, "body", string(body))
+
+	if response.Error != nil && response.Error.Message != "" {
+		return nil, fmt.Errorf("lm studio error: %s", response.Error.Message)
+	}
+
+	return &response, nil
+}
+
+func (c *Client) sendChatStream(ctx context.Context, req chatRequest, handler func(*chatStreamResponse) error) error {
+	req.Stream = true
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := c.baseURL + chatEndpoint
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	c.logger.Debug("lmstudio stream request", "url", url, "body", string(payload))
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	for key, values := range ai.DefaultHTTPHeaders() {
+		for _, value := range values {
+			httpReq.Header.Add(key, value)
+		}
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("lm studio chat request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("lm studio chat request failed: status %s: %s", resp.Status, string(body))
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "data:") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		}
+		if line == "" || line == "[DONE]" {
+			continue
+		}
+		if strings.HasPrefix(line, "event:") {
+			// LM Studio streams may include event metadata lines; skip non-JSON events.
+			continue
+		}
+		if len(line) > 0 && line[0] != '{' && line[0] != '[' {
+			continue
+		}
+
+		c.logger.Debug("lmstudio stream chunk", "chunk", line)
+
+		var chunk chatStreamResponse
+		if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+			return fmt.Errorf("decoding lm studio stream chunk: %w", err)
+		}
+
+		if err := handler(&chunk); err != nil {
+			return err
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading lm studio stream: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) emitStreamChunk(ctx context.Context, ch chan<- llmshared.StreamResult, chunk *ai.StreamChunk) error {
+	if chunk == nil {
+		return nil
+	}
+	select {
+	case ch <- llmshared.StreamResult{Chunk: chunk}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *Client) emitToolChunk(ctx context.Context, ch chan<- llmshared.StreamResult, calls []*ai.ToolCallChunk) error {
+	if len(calls) == 0 {
+		return nil
+	}
+	return c.emitStreamChunk(ctx, ch, &ai.StreamChunk{ToolCalls: calls})
+}
+
+type toolCallAccumulator struct {
+	ID        string
+	Name      string
+	Type      string
+	Arguments strings.Builder
+}
+
+func (c *Client) runStreamingChat(ctx context.Context, ch chan<- llmshared.StreamResult, req chatRequest) {
+	defer close(ch)
+
+	acc := make(map[string]*toolCallAccumulator)
+
+	err := c.sendChatStream(ctx, req, func(resp *chatStreamResponse) error {
+		if resp.Error != nil && resp.Error.Message != "" {
+			return fmt.Errorf("lm studio error: %s", resp.Error.Message)
+		}
+
+		for _, choice := range resp.Choices {
+			delta := choice.Delta
+
+			if text := delta.Text(); text != "" {
+				if err := c.emitStreamChunk(ctx, ch, &ai.StreamChunk{Text: text}); err != nil {
+					return err
+				}
+			}
+
+			if len(delta.ToolCalls) > 0 {
+				for _, call := range delta.ToolCalls {
+					entry := acc[call.ID]
+					if entry == nil {
+						entry = &toolCallAccumulator{ID: call.ID, Type: call.Type}
+						acc[call.ID] = entry
+					}
+					if call.Function.Name != "" {
+						entry.Name = call.Function.Name
+					}
+					if call.Function.Arguments != "" {
+						entry.Arguments.WriteString(call.Function.Arguments)
+					}
+				}
+			}
+
+			if len(acc) > 0 && (choice.FinishReason == "tool_calls" || choice.FinishReason == "stop" || choice.FinishReason == "") {
+				chunks := make([]*ai.ToolCallChunk, 0, len(acc))
+				for _, call := range acc {
+					params := map[string]any{}
+					args := strings.TrimSpace(call.Arguments.String())
+					if args != "" {
+						if err := json.Unmarshal([]byte(args), &params); err != nil {
+							params = map[string]any{
+								"raw": args,
+							}
+						}
+					}
+					chunks = append(chunks, &ai.ToolCallChunk{
+						ID:         call.ID,
+						Name:       call.Name,
+						Parameters: params,
+					})
+				}
+				if err := c.emitToolChunk(ctx, ch, chunks); err != nil {
+					return err
+				}
+				acc = make(map[string]*toolCallAccumulator)
+			}
+		}
+
+		if resp.Usage != nil {
+			tokenCount := c.buildTokenCount(resp.Usage)
+			c.publishTokenCount(tokenCount)
+			if tokenCount != nil {
+				if err := c.emitStreamChunk(ctx, ch, &ai.StreamChunk{TokenCount: tokenCount}); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	})
+
+	if err == nil && len(acc) > 0 {
+		chunks := make([]*ai.ToolCallChunk, 0, len(acc))
+		for _, call := range acc {
+			params := map[string]any{}
+			args := strings.TrimSpace(call.Arguments.String())
+			if args != "" {
+				if err := json.Unmarshal([]byte(args), &params); err != nil {
+					params = map[string]any{
+						"raw": args,
+					}
+				}
+			}
+			chunks = append(chunks, &ai.ToolCallChunk{
+				ID:         call.ID,
+				Name:       call.Name,
+				Parameters: params,
+			})
+		}
+		_ = c.emitToolChunk(ctx, ch, chunks)
+	}
+
+	if err != nil && ctx.Err() == nil {
+		select {
+		case ch <- llmshared.StreamResult{Err: err}:
+		case <-ctx.Done():
+		}
+	}
+}
+
+func (c *Client) renderPrompt(prompt ai.Prompt, debug bool, attrs []ai.Attr) (*ai.Prompt, error) {
+	return llmshared.RenderPromptWithDebug(c.fileManager, prompt, debug, attrs)
+}
+
+func (c *Client) publishTokenCount(tokenCount *ai.TokenCount) {
+	if tokenCount == nil {
+		return
+	}
+	event := events.TokenCountEvent{
+		InputTokens:  tokenCount.InputTokens,
+		OutputTokens: tokenCount.OutputTokens,
+		TotalTokens:  tokenCount.TotalTokens,
+	}
+	c.eventBus.Publish(event.Topic(), event)
+}
+
+func (c *Client) buildTokenCount(usage *usage) *ai.TokenCount {
+	if usage == nil {
+		return nil
+	}
+
+	input := usage.PromptTokens
+	output := usage.CompletionTokens
+	total := usage.TotalTokens
+	if total == 0 {
+		total = input + output
+	}
+
+	return &ai.TokenCount{
+		TotalTokens:  total,
+		InputTokens:  input,
+		OutputTokens: output,
+	}
+}
+
+func (c *Client) resolveBaseURL() string {
+	if env := strings.TrimSpace(c.config.GetStringWithDefault("GENIE_LMSTUDIO_BASE_URL", "")); env != "" {
+		return ensureV1Suffix(env)
+	}
+	if env := strings.TrimSpace(c.config.GetStringWithDefault("LMSTUDIO_BASE_URL", "")); env != "" {
+		return ensureV1Suffix(env)
+	}
+	if env := strings.TrimSpace(c.config.GetStringWithDefault("LM_STUDIO_BASE_URL", "")); env != "" {
+		return ensureV1Suffix(env)
+	}
+	return ensureV1Suffix(defaultBaseURL)
+}
+
+func ensureV1Suffix(base string) string {
+	base = strings.TrimRight(base, "/")
+	if base == "" {
+		return ""
+	}
+	if strings.HasSuffix(base, "/v1") {
+		return base
+	}
+	return base + "/v1"
+}
+
+func (c *Client) resolveModelName(promptModel string) string {
+	if strings.TrimSpace(promptModel) != "" {
+		return promptModel
+	}
+
+	model := c.config.GetModelConfig()
+	if strings.TrimSpace(model.ModelName) != "" {
+		return model.ModelName
+	}
+
+	return ""
+}
+
+func (c *Client) encodeImage(img *ai.Image) string {
+	if img == nil || len(img.Data) == 0 {
+		return ""
+	}
+
+	mimeType := strings.TrimSpace(img.Type)
+	if mimeType == "" {
+		mimeType = "image/png"
+	}
+
+	return fmt.Sprintf("data:%s;base64,%s", mimeType, base64.StdEncoding.EncodeToString(img.Data))
+}

--- a/pkg/llm/lmstudio/client_test.go
+++ b/pkg/llm/lmstudio/client_test.go
@@ -1,0 +1,254 @@
+package lmstudio
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kcaldas/genie/pkg/ai"
+	"github.com/kcaldas/genie/pkg/events"
+	"github.com/kcaldas/genie/pkg/logging"
+)
+
+func TestClient_GenerateContent_SimpleResponse(t *testing.T) {
+	t.Parallel()
+
+	mockHTTP := newMockHTTPClient(t, func(call int, req chatRequest) chatResponse {
+		require.Equal(t, 0, call)
+		assert.False(t, req.Stream)
+		assert.Equal(t, "local-model", req.Model)
+		require.Len(t, req.Messages, 2)
+		assert.Equal(t, "system", req.Messages[0].Role)
+		assert.Equal(t, "You are a helpful assistant.", req.Messages[0].Content.Parts[0].Text)
+		assert.Equal(t, "user", req.Messages[1].Role)
+		assert.Equal(t, "Say hello.", req.Messages[1].Content.Parts[0].Text)
+
+		return chatResponse{
+			Model: "local-model",
+			Choices: []chatChoice{{
+				Index: 0,
+				Message: responseMessage{
+					Role: "assistant",
+					Content: responseContent{
+						parts: []contentPart{{Type: "text", Text: "Hello there!"}},
+					},
+				},
+				FinishReason: "stop",
+			}},
+			Usage: &usage{
+				PromptTokens:     8,
+				CompletionTokens: 2,
+				TotalTokens:      10,
+			},
+		}
+	})
+
+	rawClient, err := NewClient(
+		&events.NoOpEventBus{},
+		WithBaseURL("http://test.local"),
+		WithHTTPClient(mockHTTP),
+		WithLogger(logging.NewDisabledLogger()),
+	)
+	require.NoError(t, err)
+	client := rawClient.(*Client)
+
+	prompt := ai.Prompt{
+		Name:        "greeting",
+		Instruction: "You are a helpful assistant.",
+		Text:        "Say hello.",
+		ModelName:   "local-model",
+	}
+
+	resp, err := client.GenerateContent(context.Background(), prompt, false)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello there!", resp)
+
+	require.Len(t, mockHTTP.requests, 1)
+}
+
+func TestClient_GenerateContent_WithToolCall(t *testing.T) {
+	t.Parallel()
+
+	mockHTTP := newMockHTTPClient(t,
+		func(call int, req chatRequest) chatResponse {
+			require.Equal(t, 0, call)
+			return chatResponse{
+				Model: "local-model",
+				Choices: []chatChoice{{
+					Index: 0,
+					Message: responseMessage{
+						Role: "assistant",
+						Content: responseContent{
+							parts: []contentPart{{Type: "text", Text: ""}},
+						},
+						ToolCalls: []toolCall{{
+							ID:   "call_1",
+							Type: "function",
+							Function: toolCallFunction{
+								Name:      "get_weather",
+								Arguments: json.RawMessage(`{"location":"Lisbon"}`),
+							},
+						}},
+					},
+					FinishReason: "tool_calls",
+				}},
+			}
+		},
+		func(call int, req chatRequest) chatResponse {
+			require.Equal(t, 1, call)
+			require.Len(t, req.Messages, 3)
+			toolMsg := req.Messages[2]
+			assert.Equal(t, "tool", toolMsg.Role)
+			assert.Equal(t, "call_1", toolMsg.ToolCallID)
+			assert.JSONEq(t, `{"temperature":22}`, toolMsg.Content.Parts[0].Text)
+
+			return chatResponse{
+				Model: "local-model",
+				Choices: []chatChoice{{
+					Index: 0,
+					Message: responseMessage{
+						Role: "assistant",
+						Content: responseContent{
+							parts: []contentPart{{Type: "text", Text: "It is sunny and 22°C."}},
+						},
+					},
+					FinishReason: "stop",
+				}},
+				Usage: &usage{PromptTokens: 20, CompletionTokens: 6, TotalTokens: 26},
+			}
+		},
+	)
+
+	rawClient, err := NewClient(
+		&events.NoOpEventBus{},
+		WithBaseURL("http://test.local"),
+		WithHTTPClient(mockHTTP),
+		WithLogger(logging.NewDisabledLogger()),
+	)
+	require.NoError(t, err)
+	client := rawClient.(*Client)
+
+	handlerInvoked := false
+	prompt := ai.Prompt{
+		Name:      "weather",
+		Text:      "What's the weather?",
+		ModelName: "local-model",
+		Functions: []*ai.FunctionDeclaration{
+			{
+				Name: "get_weather",
+				Parameters: &ai.Schema{
+					Type: ai.TypeObject,
+				},
+			},
+		},
+		Handlers: map[string]ai.HandlerFunc{
+			"get_weather": func(ctx context.Context, attr map[string]any) (map[string]any, error) {
+				handlerInvoked = true
+				assert.Equal(t, map[string]any{"location": "Lisbon"}, attr)
+				return map[string]any{"temperature": 22}, nil
+			},
+		},
+	}
+
+	resp, err := client.GenerateContent(context.Background(), prompt, false)
+	require.NoError(t, err)
+	assert.Equal(t, "It is sunny and 22°C.", resp)
+	assert.True(t, handlerInvoked)
+	assert.Equal(t, 2, mockHTTP.callCount)
+}
+
+func TestClient_CountTokens_UsesUsage(t *testing.T) {
+	t.Parallel()
+
+	mockHTTP := newMockHTTPClient(t, func(call int, req chatRequest) chatResponse {
+		require.Equal(t, 0, call)
+		if assert.NotNil(t, req.MaxTokens) {
+			assert.Equal(t, int32(0), *req.MaxTokens)
+		}
+
+		return chatResponse{
+			Model: "local-model",
+			Usage: &usage{
+				PromptTokens:     30,
+				CompletionTokens: 0,
+				TotalTokens:      30,
+			},
+		}
+	})
+
+	rawClient, err := NewClient(
+		&events.NoOpEventBus{},
+		WithBaseURL("http://test.local"),
+		WithHTTPClient(mockHTTP),
+		WithLogger(logging.NewDisabledLogger()),
+	)
+	require.NoError(t, err)
+	client := rawClient.(*Client)
+
+	prompt := ai.Prompt{
+		Name:      "count",
+		Text:      "Count tokens",
+		ModelName: "local-model",
+	}
+
+	count, err := client.CountTokens(context.Background(), prompt, false)
+	require.NoError(t, err)
+	require.NotNil(t, count)
+	assert.Equal(t, int32(30), count.TotalTokens)
+	assert.Equal(t, int32(30), count.InputTokens)
+	assert.Equal(t, int32(0), count.OutputTokens)
+}
+
+type mockHTTPClient struct {
+	t         *testing.T
+	mu        sync.Mutex
+	handlers  []func(call int, req chatRequest) chatResponse
+	requests  []chatRequest
+	callCount int
+}
+
+func newMockHTTPClient(t *testing.T, handlers ...func(call int, req chatRequest) chatResponse) *mockHTTPClient {
+	return &mockHTTPClient{
+		t:        t,
+		handlers: handlers,
+	}
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	require.Equal(m.t, http.MethodPost, req.Method)
+
+	body, err := io.ReadAll(req.Body)
+	require.NoError(m.t, err)
+	_ = req.Body.Close()
+
+	var parsed chatRequest
+	require.NoError(m.t, json.Unmarshal(body, &parsed))
+	m.requests = append(m.requests, parsed)
+
+	if m.callCount >= len(m.handlers) {
+		require.FailNow(m.t, "mock HTTP client received more calls than handlers configured")
+	}
+
+	handler := m.handlers[m.callCount]
+	response := handler(m.callCount, parsed)
+	m.callCount++
+
+	payload, err := json.Marshal(response)
+	require.NoError(m.t, err)
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(payload)),
+		Header:     make(http.Header),
+	}, nil
+}

--- a/pkg/llm/lmstudio/functions.go
+++ b/pkg/llm/lmstudio/functions.go
@@ -1,0 +1,40 @@
+package lmstudio
+
+import (
+	"strings"
+
+	"github.com/kcaldas/genie/pkg/ai"
+)
+
+func mapFunctions(functions []*ai.FunctionDeclaration) []toolDefinition {
+	if len(functions) == 0 {
+		return nil
+	}
+
+	tools := make([]toolDefinition, 0, len(functions))
+	for _, fn := range functions {
+		if fn == nil {
+			continue
+		}
+
+		definition := toolDefinition{
+			Type: "function",
+			Function: toolDefinitionDetails{
+				Name: fn.Name,
+			},
+		}
+		if strings.TrimSpace(fn.Description) != "" {
+			definition.Function.Description = fn.Description
+		}
+		if schema := schemaToMap(fn.Parameters); schema != nil {
+			definition.Function.Parameters = schema
+		}
+		tools = append(tools, definition)
+	}
+
+	if len(tools) == 0 {
+		return nil
+	}
+
+	return tools
+}

--- a/pkg/llm/lmstudio/schema.go
+++ b/pkg/llm/lmstudio/schema.go
@@ -1,0 +1,144 @@
+package lmstudio
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kcaldas/genie/pkg/ai"
+)
+
+func schemaToResponseFormat(prompt ai.Prompt) (*responseFormat, error) {
+	if prompt.ResponseSchema == nil {
+		return nil, nil
+	}
+
+	mapped := schemaToMap(prompt.ResponseSchema)
+	if mapped == nil {
+		return nil, fmt.Errorf("response schema is empty")
+	}
+
+	return &responseFormat{
+		Type: "json_schema",
+		JSONSchema: &responseFormatSchema{
+			Name:   chooseSchemaName(prompt),
+			Schema: mapped,
+			Strict: true,
+		},
+	}, nil
+}
+
+func schemaToJSON(schema *ai.Schema) (string, error) {
+	if schema == nil {
+		return "", nil
+	}
+
+	mapped := schemaToMap(schema)
+	bytes, err := json.MarshalIndent(mapped, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal schema: %w", err)
+	}
+	return string(bytes), nil
+}
+
+func schemaToMap(schema *ai.Schema) map[string]any {
+	if schema == nil {
+		return map[string]any{
+			"type": "object",
+		}
+	}
+
+	result := map[string]any{
+		"type": mapSchemaType(schema.Type),
+	}
+
+	if schema.Format != "" {
+		result["format"] = schema.Format
+	}
+	if schema.Title != "" {
+		result["title"] = schema.Title
+	}
+	if schema.Description != "" {
+		result["description"] = schema.Description
+	}
+	if schema.Nullable {
+		result["nullable"] = true
+	}
+	if schema.Enum != nil && len(schema.Enum) > 0 {
+		result["enum"] = schema.Enum
+	}
+	if schema.Minimum != 0 {
+		result["minimum"] = schema.Minimum
+	}
+	if schema.Maximum != 0 {
+		result["maximum"] = schema.Maximum
+	}
+	if schema.MinLength > 0 {
+		result["minLength"] = schema.MinLength
+	}
+	if schema.MaxLength > 0 {
+		result["maxLength"] = schema.MaxLength
+	}
+	if schema.Pattern != "" {
+		result["pattern"] = schema.Pattern
+	}
+	if schema.MinItems > 0 {
+		result["minItems"] = schema.MinItems
+	}
+	if schema.MaxItems > 0 {
+		result["maxItems"] = schema.MaxItems
+	}
+	if schema.MinProperties > 0 {
+		result["minProperties"] = schema.MinProperties
+	}
+	if schema.MaxProperties > 0 {
+		result["maxProperties"] = schema.MaxProperties
+	}
+	if schema.Required != nil && len(schema.Required) > 0 {
+		result["required"] = schema.Required
+	}
+	if schema.Items != nil {
+		result["items"] = schemaToMap(schema.Items)
+	}
+	if schema.Properties != nil && len(schema.Properties) > 0 {
+		props := make(map[string]any, len(schema.Properties))
+		for key, value := range schema.Properties {
+			props[key] = schemaToMap(value)
+		}
+		result["properties"] = props
+	} else if result["type"] == "object" {
+		// LM Studio requires an explicit properties object for tool schemas.
+		result["properties"] = map[string]any{}
+	}
+
+	return result
+}
+
+func mapSchemaType(t ai.Type) string {
+	switch t {
+	case ai.TypeString:
+		return "string"
+	case ai.TypeNumber:
+		return "number"
+	case ai.TypeInteger:
+		return "integer"
+	case ai.TypeBoolean:
+		return "boolean"
+	case ai.TypeArray:
+		return "array"
+	case ai.TypeObject:
+		return "object"
+	default:
+		return "object"
+	}
+}
+
+func chooseSchemaName(prompt ai.Prompt) string {
+	if prompt.ResponseSchema != nil && prompt.ResponseSchema.Title != "" {
+		return prompt.ResponseSchema.Title
+	}
+	if strings.TrimSpace(prompt.Name) != "" {
+		return prompt.Name
+	}
+	return "response"
+}

--- a/pkg/llm/lmstudio/types.go
+++ b/pkg/llm/lmstudio/types.go
@@ -1,0 +1,342 @@
+package lmstudio
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type requestMode int
+
+const (
+	normalMode requestMode = iota
+	countTokensMode
+)
+
+type chatRequest struct {
+	Model          string           `json:"model"`
+	Messages       []chatMessage    `json:"messages"`
+	Stream         bool             `json:"stream"`
+	Temperature    *float32         `json:"temperature,omitempty"`
+	MaxTokens      *int32           `json:"max_tokens,omitempty"`
+	TopP           *float32         `json:"top_p,omitempty"`
+	Tools          []toolDefinition `json:"tools,omitempty"`
+	ToolChoice     *string          `json:"tool_choice,omitempty"`
+	ResponseFormat *responseFormat  `json:"response_format,omitempty"`
+}
+
+type chatMessage struct {
+	Role       string         `json:"role"`
+	Content    messageContent `json:"content"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+	ToolCalls  []toolCall     `json:"tool_calls,omitempty"`
+}
+
+type messageContent struct {
+	Parts []contentPart
+}
+
+func newMessageContent(parts []contentPart) messageContent {
+	return messageContent{Parts: parts}
+}
+
+func newMessageContentFromText(text string) messageContent {
+	return messageContent{Parts: []contentPart{{Type: "text", Text: text}}}
+}
+
+func (mc messageContent) MarshalJSON() ([]byte, error) {
+	if len(mc.Parts) == 0 {
+		return json.Marshal("")
+	}
+	if len(mc.Parts) == 1 && mc.Parts[0].Type == "text" {
+		return json.Marshal(mc.Parts[0].Text)
+	}
+	return json.Marshal(mc.Parts)
+}
+
+func (mc *messageContent) UnmarshalJSON(data []byte) error {
+	data = bytesTrim(data)
+	if len(data) == 0 {
+		mc.Parts = nil
+		return nil
+	}
+	if data[0] == '"' {
+		var text string
+		if err := json.Unmarshal(data, &text); err != nil {
+			return fmt.Errorf("decode message text: %w", err)
+		}
+		mc.Parts = []contentPart{{Type: "text", Text: text}}
+		return nil
+	}
+
+	var parts []contentPart
+	if err := json.Unmarshal(data, &parts); err != nil {
+		return fmt.Errorf("decode message content parts: %w", err)
+	}
+	mc.Parts = parts
+	return nil
+}
+
+type contentPart struct {
+	Type     string    `json:"type"`
+	Text     string    `json:"text,omitempty"`
+	ImageURL *imageURL `json:"image_url,omitempty"`
+}
+
+type imageURL struct {
+	URL string `json:"url"`
+}
+
+type toolDefinition struct {
+	Type     string                `json:"type"`
+	Function toolDefinitionDetails `json:"function"`
+}
+
+type toolDefinitionDetails struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+type toolCall struct {
+	ID       string           `json:"id"`
+	Type     string           `json:"type"`
+	Function toolCallFunction `json:"function"`
+}
+
+type toolCallFunction struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+func (f toolCallFunction) ArgumentsAsMap() (map[string]any, error) {
+	if len(f.Arguments) == 0 {
+		return map[string]any{}, nil
+	}
+
+	trimmed := bytesTrim(f.Arguments)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return map[string]any{}, nil
+	}
+
+	var args map[string]any
+	if trimmed[0] == '"' {
+		var raw string
+		if err := json.Unmarshal(f.Arguments, &raw); err != nil {
+			return nil, err
+		}
+		if raw == "" {
+			return map[string]any{}, nil
+		}
+		if err := json.Unmarshal([]byte(raw), &args); err != nil {
+			return nil, err
+		}
+		return args, nil
+	}
+
+	if err := json.Unmarshal(f.Arguments, &args); err != nil {
+		return nil, err
+	}
+	if args == nil {
+		return map[string]any{}, nil
+	}
+	return args, nil
+}
+
+type chatResponse struct {
+	Model   string          `json:"model"`
+	Choices []chatChoice    `json:"choices"`
+	Usage   *usage          `json:"usage,omitempty"`
+	Error   *apiError       `json:"error,omitempty"`
+	Object  string          `json:"object,omitempty"`
+	Created int64           `json:"created,omitempty"`
+	ID      string          `json:"id,omitempty"`
+	System  json.RawMessage `json:"system,omitempty"`
+}
+
+type chatChoice struct {
+	Index        int             `json:"index"`
+	Message      responseMessage `json:"message"`
+	FinishReason string          `json:"finish_reason"`
+}
+
+type responseMessage struct {
+	Role      string          `json:"role"`
+	Content   responseContent `json:"content"`
+	ToolCalls []toolCall      `json:"tool_calls"`
+}
+
+func (rm responseMessage) toChatMessage() chatMessage {
+	return chatMessage{
+		Role:      rm.Role,
+		Content:   rm.Content.toMessageContent(),
+		ToolCalls: rm.ToolCalls,
+	}
+}
+
+type responseContent struct {
+	parts []contentPart
+}
+
+func (rc responseContent) Text() string {
+	if len(rc.parts) == 0 {
+		return ""
+	}
+	var builder strings.Builder
+	for _, part := range rc.parts {
+		if strings.TrimSpace(part.Text) != "" {
+			if builder.Len() > 0 {
+				builder.WriteString("\n")
+			}
+			builder.WriteString(part.Text)
+		}
+	}
+	return builder.String()
+}
+
+func (rc responseContent) toMessageContent() messageContent {
+	if len(rc.parts) == 0 {
+		return newMessageContentFromText("")
+	}
+	return newMessageContent(rc.parts)
+}
+
+func (rc responseContent) MarshalJSON() ([]byte, error) {
+	if len(rc.parts) == 0 {
+		return json.Marshal("")
+	}
+	if len(rc.parts) == 1 && rc.parts[0].Type == "text" {
+		return json.Marshal(rc.parts[0].Text)
+	}
+	return json.Marshal(rc.parts)
+}
+
+func (rc *responseContent) UnmarshalJSON(data []byte) error {
+	data = bytesTrim(data)
+	if len(data) == 0 {
+		rc.parts = nil
+		return nil
+	}
+	switch data[0] {
+	case '{':
+		var part contentPart
+		if err := json.Unmarshal(data, &part); err != nil {
+			return fmt.Errorf("decode message part: %w", err)
+		}
+		rc.parts = []contentPart{part}
+	case '[':
+		var parts []contentPart
+		if err := json.Unmarshal(data, &parts); err != nil {
+			return fmt.Errorf("decode message parts: %w", err)
+		}
+		rc.parts = parts
+	case '"':
+		var text string
+		if err := json.Unmarshal(data, &text); err != nil {
+			return fmt.Errorf("decode message text: %w", err)
+		}
+		rc.parts = []contentPart{{Type: "text", Text: text}}
+	default:
+		rc.parts = []contentPart{{Type: "text", Text: string(data)}}
+	}
+	return nil
+}
+
+type usage struct {
+	PromptTokens     int32 `json:"prompt_tokens"`
+	CompletionTokens int32 `json:"completion_tokens"`
+	TotalTokens      int32 `json:"total_tokens"`
+}
+
+type apiError struct {
+	Message string `json:"message"`
+	Type    string `json:"type,omitempty"`
+	Code    any    `json:"code,omitempty"`
+}
+
+type chatStreamResponse struct {
+	Choices []streamChoice `json:"choices"`
+	Usage   *usage         `json:"usage,omitempty"`
+	Error   *apiError      `json:"error,omitempty"`
+}
+
+type streamChoice struct {
+	Delta        streamDelta `json:"delta"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+type streamDelta struct {
+	Content   json.RawMessage `json:"content"`
+	Role      string          `json:"role"`
+	ToolCalls []deltaToolCall `json:"tool_calls"`
+	System    json.RawMessage `json:"system,omitempty"`
+	Refusal   json.RawMessage `json:"refusal,omitempty"`
+	Metadata  json.RawMessage `json:"metadata,omitempty"`
+	Audio     json.RawMessage `json:"audio,omitempty"`
+	Reasoning json.RawMessage `json:"reasoning,omitempty"`
+}
+
+type deltaToolCall struct {
+	ID       string            `json:"id"`
+	Type     string            `json:"type"`
+	Function deltaToolFunction `json:"function"`
+}
+
+type deltaToolFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+func (d streamDelta) Text() string {
+	data := bytesTrim(d.Content)
+	if len(data) == 0 {
+		return ""
+	}
+
+	if data[0] == '"' {
+		var text string
+		if err := json.Unmarshal(data, &text); err == nil {
+			return text
+		}
+	}
+
+	var parts []contentPart
+	if err := json.Unmarshal(data, &parts); err == nil {
+		var builder strings.Builder
+		for _, part := range parts {
+			if strings.TrimSpace(part.Text) != "" {
+				if builder.Len() > 0 {
+					builder.WriteString("\n")
+				}
+				builder.WriteString(part.Text)
+			}
+		}
+		return builder.String()
+	}
+
+	return ""
+}
+
+type responseFormat struct {
+	Type       string                 `json:"type"`
+	JSONSchema *responseFormatSchema  `json:"json_schema,omitempty"`
+	Extra      map[string]interface{} `json:"-"`
+}
+
+type responseFormatSchema struct {
+	Name   string         `json:"name"`
+	Schema map[string]any `json:"schema"`
+	Strict bool           `json:"strict"`
+}
+
+func bytesTrim(data []byte) []byte {
+	start := 0
+	end := len(data)
+	for start < end && (data[start] == ' ' || data[start] == '\n' || data[start] == '\r' || data[start] == '\t') {
+		start++
+	}
+	for end > start && (data[end-1] == ' ' || data[end-1] == '\n' || data[end-1] == '\r' || data[end-1] == '\t') {
+		end--
+	}
+	return data[start:end]
+}


### PR DESCRIPTION
## Summary
- add LM Studio backend entry (feat/lm_studio)
- fix OpenAI streaming tool call marshalling to avoid JSON payload errors
- rework event bus with per-topic buffered workers to preserve chunk order and track drops

## Testing
- GOCACHE=/Users/kcaldas/dev/genie/.gocache go test ./pkg/events
- GOCACHE=/Users/kcaldas/dev/genie/.gocache go test ./pkg/llm/openai -run TestDoesNotExist
