### PR TITLE
feat(tools): make Task async and injectable

### DIFF
--- a/pkg/genie/core.go
+++ b/pkg/genie/core.go
@@ -257,6 +257,8 @@ func (g *core) Start(workingDir *string, persona *string, opts ...StartOption) (
 		g.contextMgr.SeedChatHistory(history)
 	}
 
+	g.configureDefaultTaskExecutor()
+
 	// Set context budget based on resolved prompt (persona YAML model + budget override env var)
 	startCtx := context.WithValue(context.Background(), "genie_home", genieHomeDir)
 	startCtx = context.WithValue(startCtx, "cwd", actualWorkingDir)
@@ -331,6 +333,18 @@ func (g *core) RecalculateContextBudget(ctx context.Context) error {
 
 func (g *core) MissingTools() []string {
 	return append([]string(nil), g.missingTools...)
+}
+
+func (g *core) configureDefaultTaskExecutor() {
+	tool, ok := g.toolRegistry.Get("Task")
+	if !ok {
+		return
+	}
+	taskTool, ok := tool.(*tools.TaskTool)
+	if !ok || taskTool.HasConfiguredExecutor() {
+		return
+	}
+	taskTool.SetExecutorIfUnconfigured(newNativeTaskExecutor(g))
 }
 
 func (g *core) ensureStarted() error {

--- a/pkg/genie/options.go
+++ b/pkg/genie/options.go
@@ -19,6 +19,12 @@ type GenieOptions struct {
 	// Called with the default registry (eventBus, todoManager) dependencies
 	// Ignored if CustomRegistry is set
 	CustomRegistryFactory func(eventBus events.EventBus, todoManager tools.TodoManager) tools.Registry
+
+	// TaskExecutor overrides Genie's default subprocess executor for the Task tool.
+	TaskExecutor tools.TaskExecutor
+
+	// TaskCompletionHandler observes terminal async Task results.
+	TaskCompletionHandler tools.TaskCompletionHandler
 }
 
 // GenieOption is a function that configures GenieOptions
@@ -68,6 +74,21 @@ func WithToolRegistry(registry tools.Registry) GenieOption {
 func WithCustomRegistryFactory(factory func(events.EventBus, tools.TodoManager) tools.Registry) GenieOption {
 	return func(opts *GenieOptions) {
 		opts.CustomRegistryFactory = factory
+	}
+}
+
+// WithTaskExecutor configures how the built-in Task tool runs work.
+func WithTaskExecutor(executor tools.TaskExecutor) GenieOption {
+	return func(opts *GenieOptions) {
+		opts.TaskExecutor = executor
+	}
+}
+
+// WithTaskCompletionHandler configures a callback for completed, failed,
+// cancelled, or timed-out Task invocations.
+func WithTaskCompletionHandler(handler tools.TaskCompletionHandler) GenieOption {
+	return func(opts *GenieOptions) {
+		opts.TaskCompletionHandler = handler
 	}
 }
 

--- a/pkg/genie/task_executor.go
+++ b/pkg/genie/task_executor.go
@@ -1,0 +1,141 @@
+package genie
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kcaldas/genie/pkg/config"
+	"github.com/kcaldas/genie/pkg/ctx"
+	"github.com/kcaldas/genie/pkg/events"
+	"github.com/kcaldas/genie/pkg/persona"
+	"github.com/kcaldas/genie/pkg/prompts"
+	"github.com/kcaldas/genie/pkg/tools"
+)
+
+type nativeTaskExecutor struct {
+	parent *core
+}
+
+func newNativeTaskExecutor(parent *core) tools.TaskExecutor {
+	return &nativeTaskExecutor{parent: parent}
+}
+
+func (e *nativeTaskExecutor) RunTask(runCtx context.Context, request tools.TaskRequest, reporter tools.TaskReporter) (tools.TaskResult, error) {
+	if e == nil || e.parent == nil {
+		err := fmt.Errorf("native task executor is not configured")
+		return tools.TaskResult{Error: err.Error()}, err
+	}
+
+	parentSession, err := e.parent.sessionMgr.GetSession()
+	if err != nil {
+		return tools.TaskResult{Error: err.Error()}, err
+	}
+
+	child, childEvents, err := e.newChildGenie()
+	if err != nil {
+		return tools.TaskResult{Error: err.Error()}, err
+	}
+
+	responseCh := make(chan events.ChatResponseEvent, 1)
+	childEvents.Subscribe(events.ChatResponseEvent{}.Topic(), func(event interface{}) {
+		response, ok := event.(events.ChatResponseEvent)
+		if !ok {
+			return
+		}
+		select {
+		case responseCh <- response:
+		default:
+		}
+	})
+
+	workspace := strings.TrimSpace(request.Workspace)
+	if workspace == "" {
+		workspace = parentSession.GetWorkingDirectory()
+	}
+	personaID := strings.TrimSpace(request.Persona)
+	if personaID == "" && parentSession.GetPersona() != nil {
+		personaID = parentSession.GetPersona().GetID()
+	}
+
+	if reporter != nil {
+		reporter.Log("starting native Genie child session")
+	}
+
+	startOptions := []StartOption{
+		WithAllowedDirs(parentSession.GetAllowedDirectories()...),
+		WithDeniedPaths(parentSession.GetDeniedPaths()...),
+		WithReadOnlyPaths(parentSession.GetReadOnlyPaths()...),
+	}
+	if name, email := parentSession.GetCommitAuthor(); name != "" || email != "" {
+		startOptions = append(startOptions, WithCommitAuthor(name, email))
+	}
+
+	var personaPtr *string
+	if personaID != "" {
+		personaPtr = &personaID
+	}
+	if _, err := child.Start(&workspace, personaPtr, startOptions...); err != nil {
+		return tools.TaskResult{Error: err.Error()}, err
+	}
+
+	if err := child.Chat(runCtx, nativeTaskPrompt(request.Prompt), WithoutPromptCache()); err != nil {
+		return tools.TaskResult{Error: err.Error()}, err
+	}
+
+	select {
+	case response := <-responseCh:
+		if response.Error != nil {
+			return tools.TaskResult{Error: response.Error.Error()}, response.Error
+		}
+		return tools.TaskResult{Output: strings.TrimSpace(response.Response)}, nil
+	case <-runCtx.Done():
+		return tools.TaskResult{Error: runCtx.Err().Error()}, runCtx.Err()
+	}
+}
+
+func (e *nativeTaskExecutor) newChildGenie() (Genie, events.EventBus, error) {
+	childEvents := events.NewEventBus()
+	skillManager, err := ProvideSkillManager()
+	if err != nil {
+		return nil, nil, err
+	}
+	mcpClient, err := ProvideMCPClient()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	todoManager := tools.NewTodoManager()
+	toolRegistry := tools.NewDefaultRegistryWithoutTask(childEvents, todoManager, skillManager, mcpClient)
+	contextRegistry := provideContextRegistry(childEvents, skillManager)
+	contextManager := ctx.NewContextManager(contextRegistry)
+	promptLoader := prompts.NewPromptLoader(childEvents, toolRegistry)
+	personaPromptFactory := persona.NewPersonaPromptFactory(promptLoader, skillManager)
+	configManager := e.parent.configMgr
+	if configManager == nil {
+		configManager = config.NewConfigManager()
+	}
+	personaManager := persona.NewDefaultPersonaManager(personaPromptFactory, configManager, childEvents)
+	outputFormatter := tools.NewOutputFormatter(toolRegistry)
+	sessionManager := NewSessionManager(childEvents)
+
+	return newGenieCore(
+		e.parent.promptRunner,
+		sessionManager,
+		contextManager,
+		childEvents,
+		outputFormatter,
+		personaManager,
+		configManager,
+		toolRegistry,
+	), childEvents, nil
+}
+
+func nativeTaskPrompt(prompt string) string {
+	return fmt.Sprintf(`DEEP RESEARCH TASK:
+
+You are conducting thorough research. Examine the codebase systematically, validate findings, follow related code paths, and return concise findings with concrete file references where relevant.
+
+TASK:
+%s`, strings.TrimSpace(prompt))
+}

--- a/pkg/genie/task_executor_test.go
+++ b/pkg/genie/task_executor_test.go
@@ -1,0 +1,125 @@
+package genie
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kcaldas/genie/pkg/tools"
+)
+
+func TestStartWiresNativeTaskExecutor(t *testing.T) {
+	fixture := NewTestFixture(t)
+	session := fixture.StartAndGetSession(WithChatHistory(ChatHistoryTurn{
+		User:      "Earlier parent-only question",
+		Assistant: "Earlier parent-only answer",
+	}))
+	taskTool := taskToolFromFixture(t, fixture)
+
+	if !taskTool.HasConfiguredExecutor() {
+		t.Fatal("Task tool should have a configured native executor after Start")
+	}
+
+	childPrompt := nativeTaskPrompt("Inspect the repository and summarize what matters.")
+	fixture.ExpectSimpleMessage(childPrompt, "child task result")
+
+	taskCtx := applySessionContext(context.Background(), session)
+	start, err := taskTool.Handler()(taskCtx, map[string]any{
+		"action":     "start",
+		"summary":    "Inspect repository",
+		"prompt":     "Inspect the repository and summarize what matters.",
+		"timeout_ms": float64((30 * time.Second) / time.Millisecond),
+	})
+	if err != nil {
+		t.Fatalf("Task start failed: %v", err)
+	}
+
+	taskID, _ := start["task_id"].(string)
+	if taskID == "" {
+		t.Fatalf("Task start did not return a task id: %#v", start)
+	}
+
+	done := waitForTaskStatus(t, taskTool, taskID, 2*time.Second)
+	if done["status"] != string(tools.TaskStatusCompleted) {
+		t.Fatalf("Task status = %v, want completed; result=%#v", done["status"], done)
+	}
+	if done["result"] != "child task result" {
+		t.Fatalf("Task result = %q, want child task result", done["result"])
+	}
+
+	captured := fixture.MockPromptRunner.CapturedData()
+	if len(captured) == 0 {
+		t.Fatal("Expected child prompt data to be captured")
+	}
+	chat := captured[len(captured)-1]["chat"]
+	if strings.Contains(chat, "Earlier parent-only") {
+		t.Fatalf("Child task inherited parent chat history: %q", chat)
+	}
+}
+
+func TestNativeTaskChildRegistryOmitsTask(t *testing.T) {
+	fixture := NewTestFixture(t)
+	session := fixture.StartAndGetSession()
+
+	executor := newNativeTaskExecutor(fixture.Genie.(*core)).(*nativeTaskExecutor)
+	child, _, err := executor.newChildGenie()
+	if err != nil {
+		t.Fatalf("newChildGenie failed: %v", err)
+	}
+
+	workspace := session.GetWorkingDirectory()
+	if _, err := child.Start(&workspace, nil); err != nil {
+		t.Fatalf("child.Start failed: %v", err)
+	}
+	registry, err := child.GetToolsRegistry()
+	if err != nil {
+		t.Fatalf("child.GetToolsRegistry failed: %v", err)
+	}
+	if _, exists := registry.Get("Task"); exists {
+		t.Fatal("child registry should not include Task")
+	}
+	if _, exists := registry.Get("readFile"); !exists {
+		t.Fatal("child registry should still include regular tools")
+	}
+}
+
+func taskToolFromFixture(t *testing.T, fixture *TestFixture) *tools.TaskTool {
+	t.Helper()
+
+	registry, err := fixture.Genie.GetToolsRegistry()
+	if err != nil {
+		t.Fatalf("GetToolsRegistry failed: %v", err)
+	}
+	tool, exists := registry.Get("Task")
+	if !exists {
+		t.Fatal("Task tool not registered")
+	}
+	taskTool, ok := tool.(*tools.TaskTool)
+	if !ok {
+		t.Fatalf("Task tool type = %T, want *tools.TaskTool", tool)
+	}
+	return taskTool
+}
+
+func waitForTaskStatus(t *testing.T, taskTool *tools.TaskTool, taskID string, timeout time.Duration) map[string]any {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		result, err := taskTool.Handler()(context.Background(), map[string]any{
+			"action":  "status",
+			"task_id": taskID,
+		})
+		if err != nil {
+			t.Fatalf("Task status failed: %v", err)
+		}
+		status, _ := result["status"].(string)
+		if status != string(tools.TaskStatusRunning) {
+			return result
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("Timed out waiting for task %s", taskID)
+	return nil
+}

--- a/pkg/genie/wire.go
+++ b/pkg/genie/wire.go
@@ -95,7 +95,8 @@ func newRegistryWithOptions(
 		return options.CustomRegistryFactory(eventBus, todoManager), nil
 	}
 
-	registry := tools.NewDefaultRegistry(eventBus, todoManager, skillManager, mcpClient)
+	taskOptions := taskManagerOptionsFromGenieOptions(options)
+	registry := tools.NewDefaultRegistry(eventBus, todoManager, skillManager, mcpClient, taskOptions...)
 
 	for _, tool := range options.CustomTools {
 		if err := registry.Register(tool); err != nil {
@@ -104,6 +105,20 @@ func newRegistryWithOptions(
 	}
 
 	return registry, nil
+}
+
+func taskManagerOptionsFromGenieOptions(options *GenieOptions) []tools.TaskManagerOption {
+	if options == nil {
+		return nil
+	}
+	var taskOptions []tools.TaskManagerOption
+	if options.TaskExecutor != nil {
+		taskOptions = append(taskOptions, tools.WithTaskExecutor(options.TaskExecutor))
+	}
+	if options.TaskCompletionHandler != nil {
+		taskOptions = append(taskOptions, tools.WithTaskCompletionHandler(options.TaskCompletionHandler))
+	}
+	return taskOptions
 }
 
 // --- AI Gen provider ---

--- a/pkg/genie/wire_gen.go
+++ b/pkg/genie/wire_gen.go
@@ -271,7 +271,8 @@ func newRegistryWithOptions(
 		return options.CustomRegistryFactory(eventBus, todoManager), nil
 	}
 
-	registry := tools.NewDefaultRegistry(eventBus, todoManager, skillManager2, mcpClient)
+	taskOptions := taskManagerOptionsFromGenieOptions(options)
+	registry := tools.NewDefaultRegistry(eventBus, todoManager, skillManager2, mcpClient, taskOptions...)
 
 	for _, tool := range options.CustomTools {
 		if err := registry.Register(tool); err != nil {
@@ -280,6 +281,20 @@ func newRegistryWithOptions(
 	}
 
 	return registry, nil
+}
+
+func taskManagerOptionsFromGenieOptions(options *GenieOptions) []tools.TaskManagerOption {
+	if options == nil {
+		return nil
+	}
+	var taskOptions []tools.TaskManagerOption
+	if options.TaskExecutor != nil {
+		taskOptions = append(taskOptions, tools.WithTaskExecutor(options.TaskExecutor))
+	}
+	if options.TaskCompletionHandler != nil {
+		taskOptions = append(taskOptions, tools.WithTaskCompletionHandler(options.TaskCompletionHandler))
+	}
+	return taskOptions
 }
 
 // provideAIGen creates the AI Gen with the given event bus (per-instance).

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -60,6 +60,17 @@ func NewRegistry() Registry {
 // NewDefaultRegistry creates a registry with tools configured for interactive use.
 // If mcpClient is non-nil, MCP tools are lazily loaded when Init(workingDir) is called.
 func NewDefaultRegistry(eventBus events.EventBus, todoManager TodoManager, skillManager SkillManager, mcpClient MCPClient, taskOptions ...TaskManagerOption) Registry {
+	return newDefaultRegistry(eventBus, todoManager, skillManager, mcpClient, true, taskOptions...)
+}
+
+// NewDefaultRegistryWithoutTask creates the normal interactive registry but
+// omits Task. Native Task executors use this for child sessions to avoid
+// recursive task trees.
+func NewDefaultRegistryWithoutTask(eventBus events.EventBus, todoManager TodoManager, skillManager SkillManager, mcpClient MCPClient) Registry {
+	return newDefaultRegistry(eventBus, todoManager, skillManager, mcpClient, false)
+}
+
+func newDefaultRegistry(eventBus events.EventBus, todoManager TodoManager, skillManager SkillManager, mcpClient MCPClient, includeTask bool, taskOptions ...TaskManagerOption) Registry {
 	registry := &DefaultRegistry{
 		tools:     make(map[string]Tool),
 		toolSets:  make(map[string][]Tool),
@@ -93,8 +104,11 @@ func NewDefaultRegistry(eventBus events.EventBus, todoManager TodoManager, skill
 		NewGitRestoreTool(eventBus),                   // Restore a path from history
 		NewTodoWriteTool(todoManager),                 // Todo write tool
 		NewThinkingTool(eventBus),                     // Thinking tool
-		NewTaskTool(eventBus, taskOptions...),         // Task tool for async research
 		process.NewTool(processRegistry, eventBus),    // Process session management
+	}
+
+	if includeTask {
+		tools = append(tools, NewTaskTool(eventBus, taskOptions...)) // Task tool for async research
 	}
 
 	// Add Skill tool if skill manager is available

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -59,7 +59,7 @@ func NewRegistry() Registry {
 
 // NewDefaultRegistry creates a registry with tools configured for interactive use.
 // If mcpClient is non-nil, MCP tools are lazily loaded when Init(workingDir) is called.
-func NewDefaultRegistry(eventBus events.EventBus, todoManager TodoManager, skillManager SkillManager, mcpClient MCPClient) Registry {
+func NewDefaultRegistry(eventBus events.EventBus, todoManager TodoManager, skillManager SkillManager, mcpClient MCPClient, taskOptions ...TaskManagerOption) Registry {
 	registry := &DefaultRegistry{
 		tools:     make(map[string]Tool),
 		toolSets:  make(map[string][]Tool),
@@ -71,30 +71,30 @@ func NewDefaultRegistry(eventBus events.EventBus, todoManager TodoManager, skill
 
 	// Register all tools
 	tools := []Tool{
-		NewLsTool(eventBus),                            // List files with message support
-		NewFindTool(eventBus),                          // Find files with message support
-		NewReadFileTool(eventBus),                      // Read files with message support
-		NewViewDocumentTool(eventBus),                  // Inspect PDF documents
-		NewViewImageTool(eventBus),                     // Inspect images within the workspace
-		NewGrepTool(eventBus),                          // Search in files with message support
-		NewBashTool(eventBus, false, processRegistry),  // Bash with PTY/background support
-		NewWriteTool(eventBus, true),                   // Write files with diff preview enabled
-		NewCpTool(eventBus),                            // Copy files/dirs (workspace-restricted)
-		NewMvTool(eventBus),                            // Move/rename files/dirs (workspace-restricted)
-		NewRmTool(eventBus),                            // Remove files/dirs (workspace-restricted)
-		NewMkdirTool(eventBus),                         // Create directories (workspace-restricted)
-		NewAppendTool(eventBus),                        // Append to file (workspace-restricted)
-		NewEditTool(eventBus),                          // Edit file via str_replace or line range
-		NewGitStatusTool(eventBus),                     // Working-tree status of the active repo
-		NewGitLogTool(eventBus),                        // Commit history
-		NewGitDiffTool(eventBus),                       // Working-tree or commit diff
-		NewGitShowTool(eventBus),                       // Read file contents at a commit
-		NewGitCommitTool(eventBus),                     // Commit dirty files with host-attributed author
-		NewGitRestoreTool(eventBus),                    // Restore a path from history
-		NewTodoWriteTool(todoManager),                  // Todo write tool
-		NewThinkingTool(eventBus),                      // Thinking tool
-		NewTaskTool(eventBus),                          // Task tool for subprocess research
-		process.NewTool(processRegistry, eventBus),     // Process session management
+		NewLsTool(eventBus),                           // List files with message support
+		NewFindTool(eventBus),                         // Find files with message support
+		NewReadFileTool(eventBus),                     // Read files with message support
+		NewViewDocumentTool(eventBus),                 // Inspect PDF documents
+		NewViewImageTool(eventBus),                    // Inspect images within the workspace
+		NewGrepTool(eventBus),                         // Search in files with message support
+		NewBashTool(eventBus, false, processRegistry), // Bash with PTY/background support
+		NewWriteTool(eventBus, true),                  // Write files with diff preview enabled
+		NewCpTool(eventBus),                           // Copy files/dirs (workspace-restricted)
+		NewMvTool(eventBus),                           // Move/rename files/dirs (workspace-restricted)
+		NewRmTool(eventBus),                           // Remove files/dirs (workspace-restricted)
+		NewMkdirTool(eventBus),                        // Create directories (workspace-restricted)
+		NewAppendTool(eventBus),                       // Append to file (workspace-restricted)
+		NewEditTool(eventBus),                         // Edit file via str_replace or line range
+		NewGitStatusTool(eventBus),                    // Working-tree status of the active repo
+		NewGitLogTool(eventBus),                       // Commit history
+		NewGitDiffTool(eventBus),                      // Working-tree or commit diff
+		NewGitShowTool(eventBus),                      // Read file contents at a commit
+		NewGitCommitTool(eventBus),                    // Commit dirty files with host-attributed author
+		NewGitRestoreTool(eventBus),                   // Restore a path from history
+		NewTodoWriteTool(todoManager),                 // Todo write tool
+		NewThinkingTool(eventBus),                     // Thinking tool
+		NewTaskTool(eventBus, taskOptions...),         // Task tool for async research
+		process.NewTool(processRegistry, eventBus),    // Process session management
 	}
 
 	// Add Skill tool if skill manager is available

--- a/pkg/tools/registry_test.go
+++ b/pkg/tools/registry_test.go
@@ -53,40 +53,52 @@ func TestNewDefaultRegistry(t *testing.T) {
 	todoManager := NewTodoManager()
 	registry := NewDefaultRegistry(nil, todoManager, nil, nil) // nil eventBus, skillManager, mcpClient for tests
 	assert.NotNil(t, registry)
-	
+
 	tools := registry.GetAll()
 	assert.Greater(t, len(tools), 0, "Default registry should have tools")
-	
+
 	names := registry.Names()
 	assert.Greater(t, len(names), 0, "Default registry should have tool names")
-	
+
 	// Check for expected standard tools
 	expectedTools := []string{"listFiles", "findFiles", "readFile", "searchInFiles", "bash"}
 	for _, expected := range expectedTools {
 		_, exists := registry.Get(expected)
 		assert.True(t, exists, "Should have standard tool: %s", expected)
 	}
-	
+
 	// Check for todo tools
-	
+
 	todoWriteTool, exists := registry.Get("TodoWrite")
 	assert.True(t, exists, "Should have TodoWrite tool")
 	assert.NotNil(t, todoWriteTool)
 }
 
+func TestNewDefaultRegistryWithoutTask(t *testing.T) {
+	todoManager := NewTodoManager()
+	registry := NewDefaultRegistryWithoutTask(nil, todoManager, nil, nil)
+
+	_, exists := registry.Get("Task")
+	assert.False(t, exists, "Task tool should not be registered")
+
+	readFileTool, exists := registry.Get("readFile")
+	assert.True(t, exists, "Should still have readFile tool")
+	assert.NotNil(t, readFileTool)
+}
+
 func TestRegistry_Register(t *testing.T) {
 	registry := NewRegistry()
 	mockTool := &MockTool{name: "testTool"}
-	
+
 	// Test successful registration
 	err := registry.Register(mockTool)
 	assert.NoError(t, err)
-	
+
 	// Verify tool was registered
 	tool, exists := registry.Get("testTool")
 	assert.True(t, exists)
 	assert.Equal(t, mockTool, tool)
-	
+
 	// Test duplicate registration
 	err = registry.Register(mockTool)
 	assert.Error(t, err)
@@ -95,7 +107,7 @@ func TestRegistry_Register(t *testing.T) {
 
 func TestRegistry_RegisterNilTool(t *testing.T) {
 	registry := NewRegistry()
-	
+
 	err := registry.Register(nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot register nil tool")
@@ -104,7 +116,7 @@ func TestRegistry_RegisterNilTool(t *testing.T) {
 func TestRegistry_RegisterToolWithEmptyName(t *testing.T) {
 	registry := NewRegistry()
 	mockTool := &MockTool{name: ""}
-	
+
 	err := registry.Register(mockTool)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tool name cannot be empty")
@@ -112,21 +124,21 @@ func TestRegistry_RegisterToolWithEmptyName(t *testing.T) {
 
 func TestRegistry_GetAll(t *testing.T) {
 	registry := NewRegistry()
-	
+
 	// Initially empty
 	tools := registry.GetAll()
 	assert.Empty(t, tools)
-	
+
 	// Add some tools
 	tool1 := &MockTool{name: "tool1"}
 	tool2 := &MockTool{name: "tool2"}
-	
+
 	registry.Register(tool1)
 	registry.Register(tool2)
-	
+
 	tools = registry.GetAll()
 	assert.Len(t, tools, 2)
-	
+
 	// Verify we get copies, not references to internal state
 	toolNames := make(map[string]bool)
 	for _, tool := range tools {
@@ -139,12 +151,12 @@ func TestRegistry_GetAll(t *testing.T) {
 func TestRegistry_Get(t *testing.T) {
 	registry := NewRegistry()
 	mockTool := &MockTool{name: "testTool"}
-	
+
 	// Test getting non-existent tool
 	tool, exists := registry.Get("nonExistent")
 	assert.False(t, exists)
 	assert.Nil(t, tool)
-	
+
 	// Register and get tool
 	registry.Register(mockTool)
 	tool, exists = registry.Get("testTool")
@@ -154,18 +166,18 @@ func TestRegistry_Get(t *testing.T) {
 
 func TestRegistry_Names(t *testing.T) {
 	registry := NewRegistry()
-	
+
 	// Initially empty
 	names := registry.Names()
 	assert.Empty(t, names)
-	
+
 	// Add tools
 	tool1 := &MockTool{name: "tool1"}
 	tool2 := &MockTool{name: "tool2"}
-	
+
 	registry.Register(tool1)
 	registry.Register(tool2)
-	
+
 	names = registry.Names()
 	assert.Len(t, names, 2)
 	assert.Contains(t, names, "tool1")
@@ -175,11 +187,11 @@ func TestRegistry_Names(t *testing.T) {
 func TestRegistry_ThreadSafety(t *testing.T) {
 	registry := NewRegistry()
 	var wg sync.WaitGroup
-	
+
 	// Test concurrent registrations
 	numGoroutines := 10
 	wg.Add(numGoroutines)
-	
+
 	for i := 0; i < numGoroutines; i++ {
 		go func(id int) {
 			defer wg.Done()
@@ -187,16 +199,16 @@ func TestRegistry_ThreadSafety(t *testing.T) {
 			registry.Register(tool)
 		}(i)
 	}
-	
+
 	wg.Wait()
-	
+
 	// Verify all tools were registered
 	tools := registry.GetAll()
 	assert.Len(t, tools, numGoroutines)
-	
+
 	names := registry.Names()
 	assert.Len(t, names, numGoroutines)
-	
+
 	// Test concurrent reads
 	wg.Add(numGoroutines)
 	for i := 0; i < numGoroutines; i++ {
@@ -208,6 +220,6 @@ func TestRegistry_ThreadSafety(t *testing.T) {
 			assert.NotNil(t, tool)
 		}(i)
 	}
-	
+
 	wg.Wait()
 }

--- a/pkg/tools/task.go
+++ b/pkg/tools/task.go
@@ -192,6 +192,29 @@ func NewTaskManager(options ...TaskManagerOption) *TaskManager {
 	return manager
 }
 
+// SetExecutorIfUnconfigured installs an executor only when the manager still
+// has its inert fallback. Hosts can use this to wire a native default while
+// preserving explicit WithTaskExecutor overrides.
+func (m *TaskManager) SetExecutorIfUnconfigured(executor TaskExecutor) bool {
+	if executor == nil {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !isUnconfiguredTaskExecutor(m.executor) {
+		return false
+	}
+	m.executor = executor
+	return true
+}
+
+// HasConfiguredExecutor reports whether Task has a real executor installed.
+func (m *TaskManager) HasConfiguredExecutor() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return !isUnconfiguredTaskExecutor(m.executor)
+}
+
 // Start begins a task and returns immediately.
 func (m *TaskManager) Start(request TaskRequest) (TaskSnapshot, error) {
 	if strings.TrimSpace(request.Summary) == "" {
@@ -426,6 +449,11 @@ func normalizeTaskDedupeText(text string) string {
 	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(text))), " ")
 }
 
+func isUnconfiguredTaskExecutor(executor TaskExecutor) bool {
+	_, ok := executor.(unconfiguredTaskExecutor)
+	return ok
+}
+
 // TaskTool starts and manages isolated async task sessions.
 type TaskTool struct {
 	publisher events.Publisher
@@ -438,6 +466,23 @@ func NewTaskTool(publisher events.Publisher, options ...TaskManagerOption) Tool 
 		publisher: publisher,
 		manager:   NewTaskManager(options...),
 	}
+}
+
+// SetExecutorIfUnconfigured installs an executor only when no explicit
+// executor was configured for this Task tool.
+func (t *TaskTool) SetExecutorIfUnconfigured(executor TaskExecutor) bool {
+	if t == nil || t.manager == nil {
+		return false
+	}
+	return t.manager.SetExecutorIfUnconfigured(executor)
+}
+
+// HasConfiguredExecutor reports whether this Task tool has a real executor.
+func (t *TaskTool) HasConfiguredExecutor() bool {
+	if t == nil || t.manager == nil {
+		return false
+	}
+	return t.manager.HasConfiguredExecutor()
 }
 
 func (t *TaskTool) Declaration() *ai.FunctionDeclaration {

--- a/pkg/tools/task.go
+++ b/pkg/tools/task.go
@@ -2,241 +2,819 @@ package tools
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
-	"os/exec"
+	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/kcaldas/genie/pkg/ai"
 	"github.com/kcaldas/genie/pkg/events"
 )
 
-// TaskTool spawns a subprocess genie instance for complex research tasks
-type TaskTool struct {
-	publisher events.Publisher
+const (
+	defaultTaskTimeout        = 10 * time.Minute
+	minTaskTimeout            = 5 * time.Second
+	maxTaskTimeout            = 30 * time.Minute
+	defaultTaskMaxOutputChars = 60000
+	maxTaskMaxOutputChars     = 200000
+	defaultTaskMaxLogEntries  = 200
+	defaultMaxConcurrentTasks = 4
+	defaultTaskDedupeWindow   = 2 * time.Minute
+)
+
+var errTaskExecutorNotConfigured = errors.New("task executor is not configured")
+
+// TaskStatus is the lifecycle state for an async Task invocation.
+type TaskStatus string
+
+const (
+	TaskStatusRunning   TaskStatus = "running"
+	TaskStatusCompleted TaskStatus = "completed"
+	TaskStatusFailed    TaskStatus = "failed"
+	TaskStatusCancelled TaskStatus = "cancelled"
+	TaskStatusTimedOut  TaskStatus = "timed_out"
+)
+
+// TaskRequest is the immutable input passed to a task executor.
+type TaskRequest struct {
+	TaskID         string
+	Summary        string
+	Prompt         string
+	Workspace      string
+	Persona        string
+	Timeout        time.Duration
+	MaxOutputChars int
+	CreatedAt      time.Time
+	Metadata       map[string]string
 }
 
-// NewTaskTool creates a new task tool
-func NewTaskTool(publisher events.Publisher) Tool {
-	return &TaskTool{
-		publisher: publisher,
+// TaskResult is the executor's final output.
+type TaskResult struct {
+	Output          string
+	Error           string
+	OutputTruncated bool
+}
+
+// TaskSnapshot is a point-in-time view of a task.
+type TaskSnapshot struct {
+	TaskID          string
+	Summary         string
+	Status          TaskStatus
+	StartedAt       time.Time
+	CompletedAt     time.Time
+	Timeout         time.Duration
+	Result          string
+	Error           string
+	OutputTruncated bool
+	Logs            []string
+}
+
+// TaskReporter lets an executor append bounded diagnostic messages.
+type TaskReporter interface {
+	Log(message string)
+}
+
+// TaskExecutor runs the task body. The task manager owns lifecycle,
+// cancellation, status transitions, and completion callbacks.
+type TaskExecutor interface {
+	RunTask(ctx context.Context, request TaskRequest, reporter TaskReporter) (TaskResult, error)
+}
+
+// TaskExecutorFunc adapts a function to TaskExecutor.
+type TaskExecutorFunc func(context.Context, TaskRequest, TaskReporter) (TaskResult, error)
+
+func (f TaskExecutorFunc) RunTask(ctx context.Context, request TaskRequest, reporter TaskReporter) (TaskResult, error) {
+	return f(ctx, request, reporter)
+}
+
+type unconfiguredTaskExecutor struct{}
+
+func newUnconfiguredTaskExecutor() TaskExecutor {
+	return unconfiguredTaskExecutor{}
+}
+
+func (unconfiguredTaskExecutor) RunTask(ctx context.Context, request TaskRequest, reporter TaskReporter) (TaskResult, error) {
+	return TaskResult{Error: errTaskExecutorNotConfigured.Error()}, errTaskExecutorNotConfigured
+}
+
+// TaskCompletionHandler observes terminal task snapshots.
+type TaskCompletionHandler func(TaskSnapshot)
+
+// TaskManagerOption configures a TaskManager.
+type TaskManagerOption func(*TaskManager)
+
+// WithTaskExecutor configures the executor used by a task manager or registry.
+func WithTaskExecutor(executor TaskExecutor) TaskManagerOption {
+	return func(manager *TaskManager) {
+		if executor != nil {
+			manager.executor = executor
+		}
 	}
 }
 
-// Declaration returns the function declaration for the task tool
+// WithTaskCompletionHandler configures a terminal task callback.
+func WithTaskCompletionHandler(handler TaskCompletionHandler) TaskManagerOption {
+	return func(manager *TaskManager) {
+		manager.onComplete = handler
+	}
+}
+
+// WithTaskLimits configures manager execution limits.
+func WithTaskLimits(maxConcurrent int, maxLogEntries int) TaskManagerOption {
+	return func(manager *TaskManager) {
+		if maxConcurrent > 0 {
+			manager.maxConcurrent = maxConcurrent
+		}
+		if maxLogEntries > 0 {
+			manager.maxLogEntries = maxLogEntries
+		}
+	}
+}
+
+// TaskManager owns async task execution and bounded task state.
+type TaskManager struct {
+	executor      TaskExecutor
+	onComplete    TaskCompletionHandler
+	maxConcurrent int
+	maxLogEntries int
+	dedupeWindow  time.Duration
+
+	mu          sync.RWMutex
+	tasks       map[string]*taskRecord
+	dedupeIndex map[string]string
+	active      int
+}
+
+type taskRecord struct {
+	request TaskRequest
+	dedupe  string
+	status  TaskStatus
+	result  string
+	err     string
+	trunc   bool
+	logs    []string
+	doneAt  time.Time
+	cancel  context.CancelFunc
+}
+
+type taskReporter struct {
+	manager *TaskManager
+	taskID  string
+}
+
+func (r taskReporter) Log(message string) {
+	r.manager.appendLog(r.taskID, message)
+}
+
+var taskIDCounter uint64
+
+// NewTaskManager creates a task manager.
+func NewTaskManager(options ...TaskManagerOption) *TaskManager {
+	manager := &TaskManager{
+		executor:      newUnconfiguredTaskExecutor(),
+		maxConcurrent: defaultMaxConcurrentTasks,
+		maxLogEntries: defaultTaskMaxLogEntries,
+		dedupeWindow:  defaultTaskDedupeWindow,
+		tasks:         make(map[string]*taskRecord),
+		dedupeIndex:   make(map[string]string),
+	}
+	for _, option := range options {
+		if option != nil {
+			option(manager)
+		}
+	}
+	return manager
+}
+
+// Start begins a task and returns immediately.
+func (m *TaskManager) Start(request TaskRequest) (TaskSnapshot, error) {
+	if strings.TrimSpace(request.Summary) == "" {
+		return TaskSnapshot{}, fmt.Errorf("summary is required")
+	}
+	if strings.TrimSpace(request.Prompt) == "" {
+		return TaskSnapshot{}, fmt.Errorf("prompt is required")
+	}
+	if request.Timeout <= 0 {
+		request.Timeout = defaultTaskTimeout
+	}
+	if request.Timeout < minTaskTimeout {
+		return TaskSnapshot{}, fmt.Errorf("timeout must be at least %s", minTaskTimeout)
+	}
+	if request.Timeout > maxTaskTimeout {
+		return TaskSnapshot{}, fmt.Errorf("timeout must be at most %s", maxTaskTimeout)
+	}
+	if request.MaxOutputChars <= 0 {
+		request.MaxOutputChars = defaultTaskMaxOutputChars
+	}
+	if request.MaxOutputChars > maxTaskMaxOutputChars {
+		return TaskSnapshot{}, fmt.Errorf("max_output_chars must be at most %d", maxTaskMaxOutputChars)
+	}
+	if request.CreatedAt.IsZero() {
+		request.CreatedAt = time.Now()
+	}
+	if request.TaskID == "" {
+		request.TaskID = nextTaskID()
+	}
+	dedupe := taskDedupeKey(request)
+
+	ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
+
+	record := &taskRecord{
+		request: request,
+		dedupe:  dedupe,
+		status:  TaskStatusRunning,
+		cancel:  cancel,
+	}
+
+	m.mu.Lock()
+	if existingID := m.dedupeIndex[dedupe]; existingID != "" {
+		if existing := m.tasks[existingID]; existing != nil && !m.dedupeExpired(existing) {
+			snapshot := snapshotFor(existing)
+			m.mu.Unlock()
+			cancel()
+			return snapshot, nil
+		}
+		delete(m.dedupeIndex, dedupe)
+	}
+	if m.maxConcurrent > 0 && m.active >= m.maxConcurrent {
+		m.mu.Unlock()
+		cancel()
+		return TaskSnapshot{}, fmt.Errorf("too many active tasks (%d max)", m.maxConcurrent)
+	}
+	if _, exists := m.tasks[request.TaskID]; exists {
+		m.mu.Unlock()
+		cancel()
+		return TaskSnapshot{}, fmt.Errorf("task id already exists: %s", request.TaskID)
+	}
+	m.tasks[request.TaskID] = record
+	m.dedupeIndex[dedupe] = request.TaskID
+	m.active++
+	snapshot := snapshotFor(record)
+	m.mu.Unlock()
+
+	go m.run(ctx, request, taskReporter{manager: m, taskID: request.TaskID})
+
+	return snapshot, nil
+}
+
+// Get returns a task snapshot by id.
+func (m *TaskManager) Get(taskID string) (TaskSnapshot, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	record, ok := m.tasks[taskID]
+	if !ok {
+		return TaskSnapshot{}, false
+	}
+	return snapshotFor(record), true
+}
+
+// List returns all known task snapshots.
+func (m *TaskManager) List() []TaskSnapshot {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	snapshots := make([]TaskSnapshot, 0, len(m.tasks))
+	for _, record := range m.tasks {
+		snapshots = append(snapshots, snapshotFor(record))
+	}
+	return snapshots
+}
+
+// Cancel requests cancellation for a running task.
+func (m *TaskManager) Cancel(taskID string) (TaskSnapshot, bool) {
+	m.mu.RLock()
+	record, ok := m.tasks[taskID]
+	if !ok {
+		m.mu.RUnlock()
+		return TaskSnapshot{}, false
+	}
+	cancel := record.cancel
+	m.mu.RUnlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	snapshot, _ := m.Get(taskID)
+	return snapshot, true
+}
+
+func (m *TaskManager) run(ctx context.Context, request TaskRequest, reporter TaskReporter) {
+	result, err := m.executor.RunTask(ctx, request, reporter)
+	status := TaskStatusCompleted
+	errText := strings.TrimSpace(result.Error)
+
+	switch {
+	case ctx.Err() == context.DeadlineExceeded:
+		status = TaskStatusTimedOut
+		if errText == "" {
+			errText = fmt.Sprintf("task timed out after %s", request.Timeout.Round(time.Second))
+		}
+	case ctx.Err() == context.Canceled:
+		status = TaskStatusCancelled
+		if errText == "" {
+			errText = "task was cancelled"
+		}
+	case err != nil:
+		status = TaskStatusFailed
+		if errText == "" {
+			errText = err.Error()
+		}
+	case errText != "":
+		status = TaskStatusFailed
+	}
+
+	output, truncated := clampText(result.Output, request.MaxOutputChars)
+	if result.OutputTruncated {
+		truncated = true
+	}
+
+	m.mu.Lock()
+	record := m.tasks[request.TaskID]
+	if record != nil {
+		record.status = status
+		record.result = output
+		record.err = errText
+		record.trunc = truncated
+		record.doneAt = time.Now()
+		record.cancel = nil
+	}
+	if m.active > 0 {
+		m.active--
+	}
+	var snapshot TaskSnapshot
+	if record != nil {
+		snapshot = snapshotFor(record)
+	}
+	onComplete := m.onComplete
+	m.mu.Unlock()
+
+	if onComplete != nil && snapshot.TaskID != "" {
+		onComplete(snapshot)
+	}
+}
+
+func (m *TaskManager) dedupeExpired(record *taskRecord) bool {
+	if m.dedupeWindow <= 0 {
+		return false
+	}
+	if record.status == TaskStatusRunning {
+		return false
+	}
+	completed := record.doneAt
+	if completed.IsZero() {
+		completed = record.request.CreatedAt
+	}
+	return time.Since(completed) > m.dedupeWindow
+}
+
+func (m *TaskManager) appendLog(taskID string, message string) {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	record, ok := m.tasks[taskID]
+	if !ok {
+		return
+	}
+	record.logs = append(record.logs, message)
+	if m.maxLogEntries > 0 && len(record.logs) > m.maxLogEntries {
+		record.logs = record.logs[len(record.logs)-m.maxLogEntries:]
+	}
+}
+
+func snapshotFor(record *taskRecord) TaskSnapshot {
+	logs := make([]string, len(record.logs))
+	copy(logs, record.logs)
+	return TaskSnapshot{
+		TaskID:          record.request.TaskID,
+		Summary:         record.request.Summary,
+		Status:          record.status,
+		StartedAt:       record.request.CreatedAt,
+		CompletedAt:     record.doneAt,
+		Timeout:         record.request.Timeout,
+		Result:          record.result,
+		Error:           record.err,
+		OutputTruncated: record.trunc,
+		Logs:            logs,
+	}
+}
+
+func nextTaskID() string {
+	n := atomic.AddUint64(&taskIDCounter, 1)
+	return fmt.Sprintf("task_%x_%d", time.Now().UnixNano(), n)
+}
+
+func taskDedupeKey(request TaskRequest) string {
+	normalized := strings.Join([]string{
+		normalizeTaskDedupeText(request.Summary),
+		normalizeTaskDedupeText(request.Prompt),
+		strings.TrimSpace(request.Workspace),
+		strings.TrimSpace(request.Persona),
+	}, "\n")
+	sum := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizeTaskDedupeText(text string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(text))), " ")
+}
+
+// TaskTool starts and manages isolated async task sessions.
+type TaskTool struct {
+	publisher events.Publisher
+	manager   *TaskManager
+}
+
+// NewTaskTool creates a new task tool.
+func NewTaskTool(publisher events.Publisher, options ...TaskManagerOption) Tool {
+	return &TaskTool{
+		publisher: publisher,
+		manager:   NewTaskManager(options...),
+	}
+}
+
 func (t *TaskTool) Declaration() *ai.FunctionDeclaration {
 	return &ai.FunctionDeclaration{
 		Name:        "Task",
-		Description: "Spawn an isolated Genie session for complex research, analysis, or multi-step tasks. Use when you need to perform extensive code exploration, research patterns, or analyze large codebases without polluting the current conversation context.",
+		Description: "Start and inspect isolated async Genie tasks for complex research, analysis, summarization, or multi-step work without loading the full working context into the current conversation. Requires a configured task executor. Use start to launch work, then status/list/log/cancel to inspect it.",
 		Parameters: &ai.Schema{
 			Type:        ai.TypeObject,
-			Description: "Parameters for spawning a task session",
+			Description: "Parameters for async task management",
 			Properties: map[string]*ai.Schema{
+				"action": {
+					Type:        ai.TypeString,
+					Description: "Task action: start, status, list, log, or cancel. Defaults to start.",
+				},
 				"summary": {
 					Type:        ai.TypeString,
-					Description: "Brief summary of what this task will accomplish and why it's needed. This will be shown to the user before starting the task.",
+					Description: "Brief user-visible summary of what the task will accomplish. Required for start.",
 					MinLength:   10,
-					MaxLength:   200,
+					MaxLength:   240,
 				},
 				"prompt": {
 					Type:        ai.TypeString,
-					Description: "Detailed task description and context for the subprocess. Be specific about what you want to research, analyze, or accomplish. Include relevant file paths, patterns to look for, or specific questions to answer. Make is explicit the format of the response you want and that this not involves any code changes.",
+					Description: "Detailed instructions for the isolated task. Be specific about what to inspect, which tools to use, and the desired response format. Required for start.",
 					MinLength:   10,
-					MaxLength:   4000,
+					MaxLength:   16000,
+				},
+				"task_id": {
+					Type:        ai.TypeString,
+					Description: "Task id for status, log, or cancel.",
 				},
 				"timeout_ms": {
 					Type:        ai.TypeInteger,
-					Description: "Optional timeout in milliseconds. Default is 120000ms (2 minutes). Use higher values for complex analysis tasks",
-					Minimum:     5000,   // 5 seconds minimum
-					Maximum:     600000, // 10 minutes max
+					Description: "Optional timeout in milliseconds for start. Default is 10 minutes; max is 30 minutes.",
+					Minimum:     float64(minTaskTimeout / time.Millisecond),
+					Maximum:     float64(maxTaskTimeout / time.Millisecond),
+				},
+				"max_output_chars": {
+					Type:        ai.TypeInteger,
+					Description: "Maximum result characters retained for this task. Default is 60000; max is 200000.",
+					Minimum:     1000,
+					Maximum:     maxTaskMaxOutputChars,
 				},
 			},
-			Required: []string{"summary", "prompt"},
 		},
 		Response: &ai.Schema{
 			Type:        ai.TypeObject,
-			Description: "Result of the task execution",
+			Description: "Async task state or result",
 			Properties: map[string]*ai.Schema{
-				"success": {
-					Type:        ai.TypeBoolean,
-					Description: "Whether the task completed successfully",
+				"success":          {Type: ai.TypeBoolean, Description: "Whether the requested task action succeeded"},
+				"action":           {Type: ai.TypeString, Description: "Action that was executed"},
+				"task_id":          {Type: ai.TypeString, Description: "Task id"},
+				"status":           {Type: ai.TypeString, Description: "Task status"},
+				"summary":          {Type: ai.TypeString, Description: "Task summary"},
+				"message":          {Type: ai.TypeString, Description: "Short status message"},
+				"result":           {Type: ai.TypeString, Description: "Task result when completed"},
+				"error":            {Type: ai.TypeString, Description: "Task error when failed"},
+				"output_truncated": {Type: ai.TypeBoolean, Description: "Whether the result was truncated"},
+				"logs": {
+					Type:        ai.TypeArray,
+					Description: "Recent task log messages",
+					Items:       &ai.Schema{Type: ai.TypeString},
 				},
-				"results": {
-					Type:        ai.TypeString,
-					Description: "The task output and findings",
-				},
-				"error": {
-					Type:        ai.TypeString,
-					Description: "Error message if the task failed",
+				"tasks": {
+					Type:        ai.TypeArray,
+					Description: "Known tasks",
+					Items:       taskSnapshotSchema(),
 				},
 			},
-			Required: []string{"success", "results"},
+			Required: []string{"success", "action"},
 		},
 	}
 }
 
-// Handler returns the function handler for the task tool
 func (t *TaskTool) Handler() ai.HandlerFunc {
 	return func(ctx context.Context, params map[string]any) (map[string]any, error) {
-		// Extract required parameters
-		summary, ok := params["summary"].(string)
-		if !ok || strings.TrimSpace(summary) == "" {
-			return nil, fmt.Errorf("summary parameter is required and must be a non-empty string")
+		action := strings.ToLower(strings.TrimSpace(stringParam(params, "action")))
+		if action == "" {
+			action = "start"
 		}
 
-		prompt, ok := params["prompt"].(string)
-		if !ok || strings.TrimSpace(prompt) == "" {
-			return nil, fmt.Errorf("prompt parameter is required and must be a non-empty string")
+		switch action {
+		case "start":
+			return t.handleStart(ctx, params)
+		case "status":
+			return t.handleStatus(params)
+		case "list":
+			return t.handleList()
+		case "log":
+			return t.handleLog(params)
+		case "cancel":
+			return t.handleCancel(params)
+		default:
+			return nil, fmt.Errorf("unsupported task action: %s", action)
 		}
-
-		// Send notification about the task
-		if t.publisher != nil {
-			notification := events.NotificationEvent{
-				Message:     fmt.Sprintf("**Task Starting:** %s", summary),
-				Role:        "assistant",
-				ContentType: "markdown",
-			}
-			t.publisher.Publish(notification.Topic(), notification)
-		}
-
-		// Execute the task
-		return t.executeTask(ctx, prompt, params)
 	}
 }
 
-// executeTask executes the genie subprocess
-func (t *TaskTool) executeTask(ctx context.Context, prompt string, params map[string]any) (map[string]any, error) {
-	// Extract optional working directory
-	var cwd string
-	if cwdParam, exists := params["workspace"]; exists {
-		if cwdStr, ok := cwdParam.(string); ok {
-			cwd = strings.TrimSpace(cwdStr)
-		}
+func (t *TaskTool) handleStart(ctx context.Context, params map[string]any) (map[string]any, error) {
+	summary := strings.TrimSpace(stringParam(params, "summary"))
+	if summary == "" {
+		return nil, fmt.Errorf("summary parameter is required for start")
+	}
+	prompt := strings.TrimSpace(stringParam(params, "prompt"))
+	if prompt == "" {
+		return nil, fmt.Errorf("prompt parameter is required for start")
 	}
 
-	// If no explicit workspace provided, use session working directory from context
-	if cwd == "" {
-		if sessionCwd := ctx.Value("cwd"); sessionCwd != nil {
-			if sessionCwdStr, ok := sessionCwd.(string); ok && sessionCwdStr != "" {
-				cwd = sessionCwdStr
-			}
-		}
-	}
-
-	// Extract optional persona, default to current persona from context
-	persona := "genie" // fallback default
-	if contextPersona := ctx.Value("persona"); contextPersona != nil {
-		if personaStr, ok := contextPersona.(string); ok && strings.TrimSpace(personaStr) != "" {
-			persona = strings.TrimSpace(personaStr)
-		}
-	}
-
-	// Allow override via parameter
-	if personaParam, exists := params["persona"]; exists {
-		if personaStr, ok := personaParam.(string); ok && strings.TrimSpace(personaStr) != "" {
-			persona = strings.TrimSpace(personaStr)
-		}
-	}
-
-	// Extract optional timeout
-	var timeout time.Duration = 2 * time.Minute // Default 2 minutes
-	if timeoutParam, exists := params["timeout_ms"]; exists {
-		if timeoutMs, ok := timeoutParam.(float64); ok {
-			timeout = time.Duration(timeoutMs) * time.Millisecond
-		}
-	}
-
-	// Create context with timeout
-	execCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	// Build enhanced prompt for deep research
-	enhancedPrompt := fmt.Sprintf(`DEEP RESEARCH TASK:
-
-You are conducting thorough research. Follow this approach:
-
-1. **ANALYZE THOROUGHLY**: Examine the codebase systematically, don't stop at surface-level findings
-2. **VALIDATE FINDINGS**: Cross-reference patterns across multiple files and locations  
-3. **GO DEEPER**: When you find something interesting, investigate related code, dependencies, and usage patterns
-4. **MULTIPLE PERSPECTIVES**: Look at the problem from different angles - architecture, implementation, testing, documentation
-5. **TRACE CONNECTIONS**: Follow imports, function calls, and data flow to understand the complete picture
-6. **VERIFY ASSUMPTIONS**: Don't accept first findings - look for counter-examples and edge cases
-
-RESEARCH TASK:
-%s
-
-Provide comprehensive findings with specific file references and line numbers where relevant.`, prompt)
-
-	// Build the genie command - put global flags before subcommand
-	args := []string{}
-	if persona != "" {
-		args = append(args, "--persona", persona)
-	}
-	args = append(args, "ask", "--accept-all", enhancedPrompt)
-	// Use local build if available, fallback to installed genie
-	genieCmd := "genie"
-	if _, err := os.Stat("./build/genie"); err == nil {
-		genieCmd = "./build/genie"
-	}
-	cmd := exec.CommandContext(execCtx, genieCmd, args...)
-
-	// Set working directory if provided
-	if cwd != "" {
-		cmd.Dir = cwd
-	}
-
-	// Inherit environment variables from current process
-	cmd.Env = os.Environ()
-
-	// Execute command and capture output
-	output, err := cmd.CombinedOutput()
-
-	// Check for timeout
-	if execCtx.Err() == context.DeadlineExceeded {
-		return map[string]any{
-			"success": false,
-			"results": string(output),
-			"error":   fmt.Sprintf("task timed out after %v", timeout),
-		}, nil
-	}
-
-	// Check for other errors
+	timeout := durationParam(params, "timeout_ms", defaultTaskTimeout)
+	maxOutput := intParam(params, "max_output_chars", defaultTaskMaxOutputChars)
+	workspace, err := taskWorkspaceFromParams(ctx, params)
 	if err != nil {
-		return map[string]any{
-			"success": false,
-			"results": string(output),
-			"error":   fmt.Sprintf("task failed: %v", err),
-		}, nil
+		return nil, err
 	}
 
-	// Clean up the output (remove any command echoing)
-	results := strings.TrimSpace(string(output))
+	request := TaskRequest{
+		Summary:        summary,
+		Prompt:         prompt,
+		Workspace:      workspace,
+		Persona:        contextString(ctx, "persona", stringParam(params, "persona")),
+		Timeout:        timeout,
+		MaxOutputChars: maxOutput,
+		CreatedAt:      time.Now(),
+	}
+
+	snapshot, err := t.manager.Start(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if t.publisher != nil {
+		startMessage := fmt.Sprintf("Starting background task %s: %s", snapshot.TaskID, summary)
+		t.publisher.Publish(events.ToolCallMessageEvent{}.Topic(), events.ToolCallMessageEvent{
+			ToolName: "Task",
+			Message:  startMessage,
+		})
+		t.publisher.Publish(events.NotificationEvent{}.Topic(), events.NotificationEvent{
+			Message:     startMessage,
+			Role:        "assistant",
+			ContentType: "text",
+		})
+	}
 
 	return map[string]any{
 		"success": true,
-		"results": results,
+		"action":  "start",
+		"task_id": snapshot.TaskID,
+		"status":  string(snapshot.Status),
+		"summary": snapshot.Summary,
+		"message": fmt.Sprintf("Background task %s started. I will report back when it completes.", snapshot.TaskID),
 	}, nil
 }
 
-// FormatOutput formats task results for user display
+func taskWorkspaceFromParams(ctx context.Context, params map[string]any) (string, error) {
+	workspace := strings.TrimSpace(stringParam(params, "workspace"))
+	if workspace == "" {
+		return WorkingDirectoryFromContext(ctx), nil
+	}
+
+	resolved, valid := ResolvePathWithWorkingDirectory(ctx, workspace)
+	if !valid {
+		return "", FormatPathOutsideWorkspaceError(ctx, workspace)
+	}
+	if err := CheckPathPolicy(ctx, resolved, IntentRead); err != nil {
+		return "", err
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("workspace %q is not accessible: %w", workspace, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("workspace %q is not a directory", workspace)
+	}
+	return resolved, nil
+}
+
+func (t *TaskTool) handleStatus(params map[string]any) (map[string]any, error) {
+	taskID := strings.TrimSpace(stringParam(params, "task_id"))
+	if taskID == "" {
+		return nil, fmt.Errorf("task_id is required for status")
+	}
+	snapshot, ok := t.manager.Get(taskID)
+	if !ok {
+		return map[string]any{"success": false, "action": "status", "task_id": taskID, "error": "task not found"}, nil
+	}
+	return snapshotResult("status", snapshot, true), nil
+}
+
+func (t *TaskTool) handleList() (map[string]any, error) {
+	snapshots := t.manager.List()
+	tasks := make([]map[string]any, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		tasks = append(tasks, compactSnapshotResult(snapshot))
+	}
+	return map[string]any{
+		"success": true,
+		"action":  "list",
+		"tasks":   tasks,
+	}, nil
+}
+
+func (t *TaskTool) handleLog(params map[string]any) (map[string]any, error) {
+	taskID := strings.TrimSpace(stringParam(params, "task_id"))
+	if taskID == "" {
+		return nil, fmt.Errorf("task_id is required for log")
+	}
+	snapshot, ok := t.manager.Get(taskID)
+	if !ok {
+		return map[string]any{"success": false, "action": "log", "task_id": taskID, "error": "task not found"}, nil
+	}
+	result := snapshotResult("log", snapshot, true)
+	result["logs"] = snapshot.Logs
+	return result, nil
+}
+
+func (t *TaskTool) handleCancel(params map[string]any) (map[string]any, error) {
+	taskID := strings.TrimSpace(stringParam(params, "task_id"))
+	if taskID == "" {
+		return nil, fmt.Errorf("task_id is required for cancel")
+	}
+	snapshot, ok := t.manager.Cancel(taskID)
+	if !ok {
+		return map[string]any{"success": false, "action": "cancel", "task_id": taskID, "error": "task not found"}, nil
+	}
+	result := snapshotResult("cancel", snapshot, true)
+	result["message"] = fmt.Sprintf("Cancellation requested for task %s.", taskID)
+	return result, nil
+}
+
 func (t *TaskTool) FormatOutput(result map[string]interface{}) string {
 	success, _ := result["success"].(bool)
-	output, _ := result["results"].(string)
-	errorMsg, _ := result["error"].(string)
+	action, _ := result["action"].(string)
+	taskID, _ := result["task_id"].(string)
+	status, _ := result["status"].(string)
+	message, _ := result["message"].(string)
+	errText, _ := result["error"].(string)
+	output, _ := result["result"].(string)
 
 	if !success {
-		if errorMsg != "" {
-			return fmt.Sprintf("**Task Failed**\n```\n%s\n```", errorMsg)
+		if errText != "" {
+			return fmt.Sprintf("**Task %s failed:** %s", action, errText)
 		}
-		return "**Task Failed**"
+		return fmt.Sprintf("**Task %s failed**", action)
 	}
-
-	output = strings.TrimSpace(output)
-	if output == "" {
-		return "**Task completed successfully (no output)**"
+	if message != "" {
+		return message
 	}
+	if action == "list" {
+		tasks, _ := result["tasks"].([]map[string]any)
+		return fmt.Sprintf("**Tasks:** %d known", len(tasks))
+	}
+	if output != "" {
+		return fmt.Sprintf("**Task %s (%s)**\n\n%s", taskID, status, output)
+	}
+	if taskID != "" {
+		return fmt.Sprintf("**Task %s:** %s", taskID, status)
+	}
+	return "**Task action completed**"
+}
 
-	// Format output nicely
-	return fmt.Sprintf("**Task Results**\n\n%s", output)
+func snapshotResult(action string, snapshot TaskSnapshot, includeResult bool) map[string]any {
+	result := compactSnapshotResult(snapshot)
+	result["success"] = true
+	result["action"] = action
+	if includeResult {
+		result["result"] = snapshot.Result
+		result["error"] = snapshot.Error
+		result["output_truncated"] = snapshot.OutputTruncated
+	}
+	return result
+}
+
+func compactSnapshotResult(snapshot TaskSnapshot) map[string]any {
+	result := map[string]any{
+		"task_id": snapshot.TaskID,
+		"summary": snapshot.Summary,
+		"status":  string(snapshot.Status),
+	}
+	if !snapshot.StartedAt.IsZero() {
+		result["started_at"] = snapshot.StartedAt.Format(time.RFC3339)
+	}
+	if !snapshot.CompletedAt.IsZero() {
+		result["completed_at"] = snapshot.CompletedAt.Format(time.RFC3339)
+	}
+	return result
+}
+
+func taskSnapshotSchema() *ai.Schema {
+	return &ai.Schema{
+		Type: ai.TypeObject,
+		Properties: map[string]*ai.Schema{
+			"task_id":      {Type: ai.TypeString},
+			"summary":      {Type: ai.TypeString},
+			"status":       {Type: ai.TypeString},
+			"started_at":   {Type: ai.TypeString},
+			"completed_at": {Type: ai.TypeString},
+		},
+	}
+}
+
+func contextString(ctx context.Context, key string, fallback string) string {
+	if strings.TrimSpace(fallback) != "" {
+		return strings.TrimSpace(fallback)
+	}
+	value := ctx.Value(key)
+	if str, ok := value.(string); ok {
+		return strings.TrimSpace(str)
+	}
+	return ""
+}
+
+func stringParam(params map[string]any, key string) string {
+	value, ok := params[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprintf("%v", typed)
+	}
+}
+
+func intParam(params map[string]any, key string, fallback int) int {
+	value, ok := params[key]
+	if !ok || value == nil {
+		return fallback
+	}
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case string:
+		if parsed, err := strconv.Atoi(strings.TrimSpace(typed)); err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func durationParam(params map[string]any, key string, fallback time.Duration) time.Duration {
+	value, ok := params[key]
+	if !ok || value == nil {
+		return fallback
+	}
+	var millis int64
+	switch typed := value.(type) {
+	case int:
+		millis = int64(typed)
+	case int64:
+		millis = typed
+	case float64:
+		millis = int64(typed)
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+		if err != nil {
+			return fallback
+		}
+		millis = parsed
+	default:
+		return fallback
+	}
+	if millis <= 0 {
+		return fallback
+	}
+	return time.Duration(millis) * time.Millisecond
+}
+
+func clampText(text string, maxChars int) (string, bool) {
+	if maxChars <= 0 || len(text) <= maxChars {
+		return text, false
+	}
+	if maxChars <= 20 {
+		return text[:maxChars], true
+	}
+	return text[:maxChars] + "\n\n[output truncated]", true
 }

--- a/pkg/tools/task_test.go
+++ b/pkg/tools/task_test.go
@@ -1,0 +1,272 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kcaldas/genie/pkg/ai"
+)
+
+func TestTaskToolStartIsAsyncAndCompletionCallbackFires(t *testing.T) {
+	release := make(chan struct{})
+	completed := make(chan TaskSnapshot, 1)
+
+	tool := NewTaskTool(nil,
+		WithTaskExecutor(TaskExecutorFunc(func(ctx context.Context, request TaskRequest, reporter TaskReporter) (TaskResult, error) {
+			reporter.Log("child task started")
+			select {
+			case <-release:
+				return TaskResult{Output: "final answer"}, nil
+			case <-ctx.Done():
+				return TaskResult{Error: ctx.Err().Error()}, ctx.Err()
+			}
+		})),
+		WithTaskCompletionHandler(func(snapshot TaskSnapshot) {
+			completed <- snapshot
+		}),
+	)
+
+	result, err := tool.Handler()(context.Background(), map[string]any{
+		"action":     "start",
+		"summary":    "Summarize recent owner conversations",
+		"prompt":     "Read the relevant conversations and return a concise summary.",
+		"timeout_ms": float64((30 * time.Second) / time.Millisecond),
+	})
+	if err != nil {
+		t.Fatalf("Task start failed: %v", err)
+	}
+
+	taskID, _ := result["task_id"].(string)
+	if taskID == "" {
+		t.Fatalf("Task start did not return a task id: %#v", result)
+	}
+	if result["status"] != string(TaskStatusRunning) {
+		t.Fatalf("Task status = %v, want running", result["status"])
+	}
+
+	status, err := tool.Handler()(context.Background(), map[string]any{
+		"action":  "status",
+		"task_id": taskID,
+	})
+	if err != nil {
+		t.Fatalf("Task status failed: %v", err)
+	}
+	if status["status"] != string(TaskStatusRunning) {
+		t.Fatalf("Task status = %v, want running", status["status"])
+	}
+
+	close(release)
+
+	var snapshot TaskSnapshot
+	select {
+	case snapshot = <-completed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for task completion callback")
+	}
+
+	if snapshot.TaskID != taskID {
+		t.Fatalf("Completion task id = %s, want %s", snapshot.TaskID, taskID)
+	}
+	if snapshot.Status != TaskStatusCompleted {
+		t.Fatalf("Completion status = %s, want completed", snapshot.Status)
+	}
+	if snapshot.Result != "final answer" {
+		t.Fatalf("Completion result = %q, want final answer", snapshot.Result)
+	}
+	if len(snapshot.Logs) != 1 || snapshot.Logs[0] != "child task started" {
+		t.Fatalf("Completion logs = %#v", snapshot.Logs)
+	}
+}
+
+func TestTaskToolCancelRequestsCancellation(t *testing.T) {
+	completed := make(chan TaskSnapshot, 1)
+
+	tool := NewTaskTool(nil,
+		WithTaskExecutor(TaskExecutorFunc(func(ctx context.Context, request TaskRequest, reporter TaskReporter) (TaskResult, error) {
+			<-ctx.Done()
+			return TaskResult{Error: ctx.Err().Error()}, ctx.Err()
+		})),
+		WithTaskCompletionHandler(func(snapshot TaskSnapshot) {
+			completed <- snapshot
+		}),
+	)
+
+	result, err := tool.Handler()(context.Background(), map[string]any{
+		"action":     "start",
+		"summary":    "Cancelable background task",
+		"prompt":     "Wait until cancelled.",
+		"timeout_ms": float64((30 * time.Second) / time.Millisecond),
+	})
+	if err != nil {
+		t.Fatalf("Task start failed: %v", err)
+	}
+	taskID := result["task_id"].(string)
+
+	_, err = tool.Handler()(context.Background(), map[string]any{
+		"action":  "cancel",
+		"task_id": taskID,
+	})
+	if err != nil {
+		t.Fatalf("Task cancel failed: %v", err)
+	}
+
+	select {
+	case snapshot := <-completed:
+		if snapshot.Status != TaskStatusCancelled {
+			t.Fatalf("Completion status = %s, want cancelled", snapshot.Status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for cancellation")
+	}
+}
+
+func TestTaskToolDuplicateStartsReuseExistingTask(t *testing.T) {
+	release := make(chan struct{})
+	var runs int32
+
+	tool := NewTaskTool(nil,
+		WithTaskExecutor(TaskExecutorFunc(func(ctx context.Context, request TaskRequest, reporter TaskReporter) (TaskResult, error) {
+			atomic.AddInt32(&runs, 1)
+			select {
+			case <-release:
+				return TaskResult{Output: "done"}, nil
+			case <-ctx.Done():
+				return TaskResult{Error: ctx.Err().Error()}, ctx.Err()
+			}
+		})),
+	)
+	defer close(release)
+
+	params := map[string]any{
+		"action":     "start",
+		"summary":    "Summarize recent owner conversations",
+		"prompt":     "Read the relevant conversations and return a concise summary.",
+		"timeout_ms": float64((30 * time.Second) / time.Millisecond),
+	}
+	first, err := tool.Handler()(context.Background(), params)
+	if err != nil {
+		t.Fatalf("First task start failed: %v", err)
+	}
+	second, err := tool.Handler()(context.Background(), map[string]any{
+		"action":     "start",
+		"summary":    "  summarize   recent OWNER conversations ",
+		"prompt":     "Read the relevant conversations and return a concise summary.",
+		"timeout_ms": float64((30 * time.Second) / time.Millisecond),
+	})
+	if err != nil {
+		t.Fatalf("Second task start failed: %v", err)
+	}
+
+	if first["task_id"] == "" || first["task_id"] != second["task_id"] {
+		t.Fatalf("Duplicate task ids = %v and %v, want same non-empty id", first["task_id"], second["task_id"])
+	}
+	waitForTaskRuns(t, &runs, 1)
+	if got := atomic.LoadInt32(&runs); got != 1 {
+		t.Fatalf("Executor runs = %d, want 1", got)
+	}
+}
+
+func TestTaskManagerWithoutExecutorFailsTaskInertly(t *testing.T) {
+	completed := make(chan TaskSnapshot, 1)
+	manager := NewTaskManager(
+		WithTaskCompletionHandler(func(snapshot TaskSnapshot) {
+			completed <- snapshot
+		}),
+	)
+
+	snapshot, err := manager.Start(TaskRequest{
+		Summary: "Unconfigured executor test",
+		Prompt:  "This task should fail because no executor is configured.",
+		Timeout: 30 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Task start failed: %v", err)
+	}
+	if snapshot.Status != TaskStatusRunning {
+		t.Fatalf("Start status = %s, want running", snapshot.Status)
+	}
+
+	select {
+	case done := <-completed:
+		if done.Status != TaskStatusFailed {
+			t.Fatalf("Completion status = %s, want failed", done.Status)
+		}
+		if !strings.Contains(done.Error, "not configured") {
+			t.Fatalf("Completion error = %q, want not configured", done.Error)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for task completion")
+	}
+}
+
+func waitForTaskRuns(t *testing.T, runs *int32, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(runs) >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("Timed out waiting for executor runs >= %d; got %d", want, atomic.LoadInt32(runs))
+}
+
+func TestTaskDeclarationArraySchemasHaveItems(t *testing.T) {
+	decl := NewTaskTool(nil).Declaration()
+	if decl.Response == nil {
+		t.Fatal("Task response schema is nil")
+	}
+
+	for _, name := range []string{"logs", "tasks"} {
+		schema := decl.Response.Properties[name]
+		if schema == nil {
+			t.Fatalf("Missing response schema for %s", name)
+		}
+		if schema.Type != ai.TypeArray {
+			t.Fatalf("%s schema type = %v, want array", name, schema.Type)
+		}
+		if schema.Items == nil {
+			t.Fatalf("%s schema is missing Items", name)
+		}
+	}
+}
+
+func TestTaskManagerClampsOutput(t *testing.T) {
+	completed := make(chan TaskSnapshot, 1)
+	manager := NewTaskManager(
+		WithTaskExecutor(TaskExecutorFunc(func(ctx context.Context, request TaskRequest, reporter TaskReporter) (TaskResult, error) {
+			return TaskResult{Output: strings.Repeat("x", 100)}, nil
+		})),
+		WithTaskCompletionHandler(func(snapshot TaskSnapshot) {
+			completed <- snapshot
+		}),
+	)
+
+	snapshot, err := manager.Start(TaskRequest{
+		Summary:        "Clamp output test",
+		Prompt:         "Return long output.",
+		Timeout:        30 * time.Second,
+		MaxOutputChars: 25,
+	})
+	if err != nil {
+		t.Fatalf("Task start failed: %v", err)
+	}
+	if snapshot.Status != TaskStatusRunning {
+		t.Fatalf("Start status = %s, want running", snapshot.Status)
+	}
+
+	select {
+	case done := <-completed:
+		if !done.OutputTruncated {
+			t.Fatal("Expected output to be truncated")
+		}
+		if len(done.Result) <= 25 {
+			t.Fatalf("Expected truncation marker, got %q", done.Result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for completion")
+	}
+}

--- a/pkg/tools/task_test.go
+++ b/pkg/tools/task_test.go
@@ -202,6 +202,58 @@ func TestTaskManagerWithoutExecutorFailsTaskInertly(t *testing.T) {
 	}
 }
 
+func TestTaskToolSetExecutorIfUnconfiguredPreservesExplicitExecutor(t *testing.T) {
+	var explicitRuns int32
+	var defaultRuns int32
+	tool, ok := NewTaskTool(nil,
+		WithTaskExecutor(TaskExecutorFunc(func(ctx context.Context, request TaskRequest, reporter TaskReporter) (TaskResult, error) {
+			atomic.AddInt32(&explicitRuns, 1)
+			return TaskResult{Output: "explicit"}, nil
+		})),
+	).(*TaskTool)
+	if !ok {
+		t.Fatal("NewTaskTool did not return *TaskTool")
+	}
+
+	if !tool.HasConfiguredExecutor() {
+		t.Fatal("Expected explicit executor to be configured")
+	}
+	if tool.SetExecutorIfUnconfigured(TaskExecutorFunc(func(ctx context.Context, request TaskRequest, reporter TaskReporter) (TaskResult, error) {
+		atomic.AddInt32(&defaultRuns, 1)
+		return TaskResult{Output: "default"}, nil
+	})) {
+		t.Fatal("SetExecutorIfUnconfigured should not override explicit executor")
+	}
+
+	completed := make(chan TaskSnapshot, 1)
+	tool.manager.onComplete = func(snapshot TaskSnapshot) {
+		completed <- snapshot
+	}
+	_, err := tool.manager.Start(TaskRequest{
+		Summary: "Explicit executor test",
+		Prompt:  "Run through explicit executor.",
+		Timeout: 30 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Task start failed: %v", err)
+	}
+
+	select {
+	case done := <-completed:
+		if done.Result != "explicit" {
+			t.Fatalf("Task result = %q, want explicit", done.Result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for task completion")
+	}
+	if atomic.LoadInt32(&explicitRuns) != 1 {
+		t.Fatalf("explicit executor runs = %d, want 1", explicitRuns)
+	}
+	if atomic.LoadInt32(&defaultRuns) != 0 {
+		t.Fatalf("default executor runs = %d, want 0", defaultRuns)
+	}
+}
+
 func waitForTaskRuns(t *testing.T, runs *int32, want int32) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)


### PR DESCRIPTION
## Summary
- replace the synchronous Task subprocess wrapper with an async Task manager
- add injectable Task executor and completion hooks for host integrations
- keep default subprocess execution for standalone Genie
- add duplicate-start protection for repeated Task start calls

## Tests
- go test ./pkg/tools ./pkg/genie
- go test ./...