### PR TITLE
fix(mcp): safe request ids for tool calls + surface server connect errors

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/kcaldas/genie/pkg/ai"
@@ -20,6 +21,16 @@ type Client struct {
 	mu           sync.RWMutex
 	initialized  bool
 	serverErrors map[string]string
+	requestID    atomic.Int64
+}
+
+// nextRequestID returns a monotonically increasing JSON-RPC request id.
+// IDs must stay well within JavaScript's safe-integer range (2^53): Node-based
+// MCP servers parse JSON numbers as doubles and silently drop requests whose
+// id fails integer validation (e.g. a UnixNano timestamp).
+func (c *Client) nextRequestID() int64 {
+	// Start after the fixed ids used by initializeServer (1) and discoverTools (2).
+	return c.requestID.Add(1) + 2
 }
 
 // ServerConnection represents a connection to an MCP server
@@ -353,21 +364,16 @@ func (c *Client) CallTool(ctx context.Context, toolName string, arguments map[st
 		Arguments: arguments,
 	}
 
-	req := NewRequest(time.Now().UnixNano(), "tools/call", callReq)
+	req := NewRequest(c.nextRequestID(), "tools/call", callReq)
 	if err := transport.Send(ctx, req); err != nil {
 		return nil, fmt.Errorf("failed to send tools/call request: %w", err)
 	}
 
-	// Receive tool call response
-	respData, err := transport.Receive(ctx)
+	// Receive the response matching our request id, skipping unrelated
+	// messages such as server notifications.
+	resp, err := c.receiveResponseForRequest(ctx, transport, req.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to receive tools/call response: %w", err)
-	}
-
-	// Parse response
-	var resp Response
-	if err := json.Unmarshal(respData, &resp); err != nil {
-		return nil, fmt.Errorf("failed to parse tools/call response: %w", err)
 	}
 
 	if resp.Error != nil {

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -13,12 +13,13 @@ import (
 
 // Client represents an MCP client that can connect to MCP servers
 type Client struct {
-	config      *Config
-	servers     map[string]*ServerConnection
-	tools       map[string]*MCPTool
-	transport   *TransportFactory
-	mu          sync.RWMutex
-	initialized bool
+	config       *Config
+	servers      map[string]*ServerConnection
+	tools        map[string]*MCPTool
+	transport    *TransportFactory
+	mu           sync.RWMutex
+	initialized  bool
+	serverErrors map[string]string
 }
 
 // ServerConnection represents a connection to an MCP server
@@ -41,11 +42,12 @@ type MCPTool struct {
 // NewClient creates a new MCP client (uninitialized - call Init to connect)
 func NewClient(config *Config) *Client {
 	return &Client{
-		config:      config,
-		servers:     make(map[string]*ServerConnection),
-		tools:       make(map[string]*MCPTool),
-		transport:   NewTransportFactory(),
-		initialized: false,
+		config:       config,
+		servers:      make(map[string]*ServerConnection),
+		tools:        make(map[string]*MCPTool),
+		serverErrors: make(map[string]string),
+		transport:    NewTransportFactory(),
+		initialized:  false,
 	}
 }
 
@@ -85,10 +87,12 @@ func (c *Client) Init(workingDir string) error {
 
 	for serverName, serverConfig := range c.config.McpServers {
 		if err := c.connectToServer(ctx, serverName, serverConfig); err != nil {
-			// Log error but continue with other servers
+			// Record error but continue with other servers
+			c.serverErrors[serverName] = err.Error()
 			fmt.Printf("Failed to connect to MCP server %s: %v\n", serverName, err)
 			continue
 		}
+		delete(c.serverErrors, serverName)
 	}
 
 	c.initialized = true
@@ -102,10 +106,12 @@ func (c *Client) ConnectToServers(ctx context.Context) error {
 
 	for serverName, serverConfig := range c.config.McpServers {
 		if err := c.connectToServer(ctx, serverName, serverConfig); err != nil {
-			// Log error but continue with other servers
+			// Record error but continue with other servers
+			c.serverErrors[serverName] = err.Error()
 			fmt.Printf("Failed to connect to MCP server %s: %v\n", serverName, err)
 			continue
 		}
+		delete(c.serverErrors, serverName)
 	}
 
 	return nil
@@ -243,7 +249,7 @@ func (c *Client) discoverTools(ctx context.Context, conn *ServerConnection) erro
 // receiveResponseForRequest receives responses until it finds one matching the request ID
 func (c *Client) receiveResponseForRequest(ctx context.Context, transport Transport, requestID interface{}) (*Response, error) {
 	requestIDStr := fmt.Sprintf("%v", requestID)
-	
+
 	for i := 0; i < 5; i++ { // Try up to 5 responses
 		respData, err := transport.Receive(ctx)
 		if err != nil {
@@ -275,6 +281,19 @@ func (c *Client) GetTools() []tools.Tool {
 	var result []tools.Tool
 	for _, mcpTool := range c.tools {
 		result = append(result, mcpTool)
+	}
+	return result
+}
+
+// ServerErrors returns the last connection error per configured server that
+// failed to connect. Servers that connected successfully are absent.
+func (c *Client) ServerErrors() map[string]string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	result := make(map[string]string, len(c.serverErrors))
+	for name, msg := range c.serverErrors {
+		result[name] = msg
 	}
 	return result
 }
@@ -438,7 +457,7 @@ func (t *MCPTool) Handler() ai.HandlerFunc {
 
 		// Convert result to match MCP spec format
 		return map[string]interface{}{
-			"content":  contentMaps,
+			"content": contentMaps,
 			"isError": result.IsError,
 		}, nil
 	}
@@ -462,7 +481,6 @@ func (t *MCPTool) FormatOutput(result map[string]interface{}) string {
 
 	return output
 }
-
 
 // convertMCPSchemaToGenieSchema converts MCP tool schema to Genie's ai.Schema
 func convertMCPSchemaToGenieSchema(mcpSchema ToolSchema) *ai.Schema {

--- a/pkg/mcp/server_errors_test.go
+++ b/pkg/mcp/server_errors_test.go
@@ -53,3 +53,24 @@ func TestInitNoConfigNoServerErrors(t *testing.T) {
 		t.Fatalf("Expected no server errors without config, got %v", errs)
 	}
 }
+
+func TestNextRequestIDStaysInSafeIntegerRange(t *testing.T) {
+	// Node-based MCP servers parse JSON numbers as IEEE doubles and silently
+	// drop requests whose id exceeds 2^53 (e.g. UnixNano timestamps).
+	const maxSafeInteger = 1 << 53
+	client := NewClient(nil)
+	var prev int64
+	for i := 0; i < 1000; i++ {
+		id := client.nextRequestID()
+		if id >= maxSafeInteger {
+			t.Fatalf("request id %d exceeds JavaScript safe-integer range", id)
+		}
+		if id <= prev {
+			t.Fatalf("request ids must be monotonically increasing, got %d after %d", id, prev)
+		}
+		if id <= 2 {
+			t.Fatalf("request id %d collides with fixed init/list ids", id)
+		}
+		prev = id
+	}
+}

--- a/pkg/mcp/server_errors_test.go
+++ b/pkg/mcp/server_errors_test.go
@@ -1,0 +1,55 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInitRecordsServerConnectErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	configContent := `{
+  "mcpServers": {
+    "broken": {
+      "command": "definitely-not-a-real-binary-xyz",
+      "args": []
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".mcp.json"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	client := NewClient(nil)
+	if err := client.Init(tmpDir); err != nil {
+		t.Fatalf("Init must not fail on a broken server, got: %v", err)
+	}
+
+	errs := client.ServerErrors()
+	if len(errs) != 1 {
+		t.Fatalf("Expected 1 server error, got %d: %v", len(errs), errs)
+	}
+	msg, ok := errs["broken"]
+	if !ok {
+		t.Fatalf("Expected error recorded for server %q, got %v", "broken", errs)
+	}
+	if !strings.Contains(msg, "definitely-not-a-real-binary-xyz") {
+		t.Errorf("Expected error message to name the missing binary, got %q", msg)
+	}
+
+	if len(client.GetTools()) != 0 {
+		t.Errorf("Expected no tools from a broken server, got %d", len(client.GetTools()))
+	}
+}
+
+func TestInitNoConfigNoServerErrors(t *testing.T) {
+	client := NewClient(nil)
+	if err := client.Init(t.TempDir()); err != nil {
+		t.Fatalf("Init without config must succeed, got: %v", err)
+	}
+	if errs := client.ServerErrors(); len(errs) != 0 {
+		t.Fatalf("Expected no server errors without config, got %v", errs)
+	}
+}

--- a/pkg/prompts/loader_toolset_test.go
+++ b/pkg/prompts/loader_toolset_test.go
@@ -71,6 +71,10 @@ func (m *MockRegistry) Init(workingDir string) error {
 	return nil
 }
 
+func (m *MockRegistry) MCPServerErrors() map[string]string {
+	return map[string]string{}
+}
+
 func TestAddToolsWithToolSets(t *testing.T) {
 	// Create mock registry
 	registry := NewMockRegistry()

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -38,6 +38,11 @@ type Registry interface {
 	// Init initializes the registry with the given working directory.
 	// This triggers MCP discovery and connection for the specified directory.
 	Init(workingDir string) error
+
+	// MCPServerErrors returns the last connection error per configured MCP
+	// server that failed to connect, keyed by server name. Empty when all
+	// servers connected or no MCP client is configured.
+	MCPServerErrors() map[string]string
 }
 
 // DefaultRegistry is a thread-safe implementation of Registry
@@ -144,6 +149,9 @@ type MCPClient interface {
 	// Init initializes the MCP client with the given working directory.
 	// This discovers MCP config and connects to servers.
 	Init(workingDir string) error
+	// ServerErrors returns the last connection error per configured server
+	// that failed to connect, keyed by server name.
+	ServerErrors() map[string]string
 }
 
 // Register adds a tool to the registry
@@ -312,4 +320,15 @@ func (r *DefaultRegistry) Init(workingDir string) error {
 
 	r.initialized = true
 	return nil
+}
+
+// MCPServerErrors returns per-server connection errors from the MCP client.
+func (r *DefaultRegistry) MCPServerErrors() map[string]string {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	if r.mcpClient == nil {
+		return map[string]string{}
+	}
+	return r.mcpClient.ServerErrors()
 }

--- a/pkg/tools/registry_toolset_test.go
+++ b/pkg/tools/registry_toolset_test.go
@@ -221,3 +221,7 @@ func (m *MockMCPClient) GetToolsByServer() map[string][]Tool {
 func (m *MockMCPClient) Init(workingDir string) error {
 	return nil
 }
+
+func (m *MockMCPClient) ServerErrors() map[string]string {
+	return map[string]string{}
+}


### PR DESCRIPTION
## Why

Two MCP client fixes found while debugging a Mutiro agent whose MCP tools listed fine but never executed:

1. **Every tool call against a Node-based MCP server hung forever.** `tools/call` used `time.Now().UnixNano()` as the JSON-RPC request id. Node parses JSON numbers as IEEE doubles; ids beyond the safe-integer range (2^53) fail the MCP SDK's validation and the request is dropped with no response. `initialize`/`tools/list` use fixed ids 1 and 2, so connection and discovery worked — tools appeared available, every execution died silently. Verified against a live server: identical call with id `7` responds in ~2s, with a UnixNano id it never responds.

2. **Server connect failures were invisible to embedders.** Errors were printed to stdout and dropped, so callers could not distinguish "no servers configured" from "server failed to spawn" (e.g. `npx` missing from PATH).

## What

- `tools/call` ids come from a monotonic in-range counter; `CallTool` now matches the response by id (skipping unrelated notifications) instead of taking the next line raw.
- `mcp.Client` records the last connect error per failed server, exposed via `Client.ServerErrors()` and `Registry.MCPServerErrors()`. Connecting stays non-blocking: a failed server degrades the tool surface, never fails `Init`.

## Testing

- New tests: connect-error capture, no-config case, request-id range/monotonicity/collision.
- Full `./pkg/...` suite green.
- Live end-to-end: previously-hanging tool call returns in <1s.

Consumed by mutirolabs/mutiro#294 (pins this branch's commit).