### PR TITLE
feat(mcp): per-server display metadata for MCP tools

### DIFF
--- a/cmd/tui/controllers/chat_test.go
+++ b/cmd/tui/controllers/chat_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/awesome-gocui/gocui"
@@ -24,6 +25,10 @@ func createTestConfigManager() *helpers.ConfigManager {
 
 // mockGuiCommon implements types.IGuiCommon for testing
 type mockGuiCommon struct {
+	// PostUIUpdate is called from concurrent event-bus handler goroutines
+	// (the real gocui implementation is thread-safe), so the mock must be
+	// safe for concurrent use too.
+	mu              sync.Mutex
 	updateCallbacks []func()
 }
 
@@ -36,7 +41,9 @@ func (m *mockGuiCommon) GetTheme() *types.Theme {
 func (m *mockGuiCommon) SetCurrentComponent(ctx types.Component) {}
 func (m *mockGuiCommon) GetCurrentComponent() types.Component    { return nil }
 func (m *mockGuiCommon) PostUIUpdate(fn func()) {
+	m.mu.Lock()
 	m.updateCallbacks = append(m.updateCallbacks, fn)
+	m.mu.Unlock()
 	fn() // Execute immediately for testing
 }
 

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -347,6 +347,35 @@ func (c *Client) GetToolsByServer() map[string][]tools.Tool {
 	return result
 }
 
+// ToolsMeta returns display metadata for every discovered tool, keyed by
+// tool name. Per-tool config overrides win over server-level config; the
+// server-advertised title is the display-name fallback.
+func (c *Client) ToolsMeta() map[string]tools.MCPToolMeta {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	result := make(map[string]tools.MCPToolMeta, len(c.tools))
+	for name, mcpTool := range c.tools {
+		serverCfg := c.config.McpServers[mcpTool.serverName]
+		meta := tools.MCPToolMeta{
+			Server:            mcpTool.serverName,
+			ServerDisplayName: serverCfg.DisplayName,
+			DisplayName:       mcpTool.mcpTool.Title,
+			SignalText:        serverCfg.SignalText,
+		}
+		if override, ok := serverCfg.Tools[name]; ok {
+			if override.DisplayName != "" {
+				meta.DisplayName = override.DisplayName
+			}
+			if !override.SignalText.IsZero() {
+				meta.SignalText = override.SignalText
+			}
+		}
+		result[name] = meta
+	}
+	return result
+}
+
 // Ensure Client implements the MCPClient interface
 var _ tools.MCPClient = (*Client)(nil)
 

--- a/pkg/mcp/config.go
+++ b/pkg/mcp/config.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/kcaldas/genie/pkg/tools"
 )
 
 // Config represents the structure of .mcp.json configuration files
@@ -25,6 +27,22 @@ type ServerConfig struct {
 	Type    string            `json:"type,omitempty"`
 	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
+
+	// Display metadata (Genie extension; other .mcp.json readers ignore
+	// these fields). DisplayName is the human-readable server name used
+	// to group its tools. SignalText is the progress text hosts may show
+	// while any of this server's tools runs. Tools carries per-tool
+	// overrides keyed by tool name.
+	DisplayName string                       `json:"displayName,omitempty"`
+	SignalText  tools.LocalizedText          `json:"signalText,omitempty"`
+	Tools       map[string]ToolDisplayConfig `json:"tools,omitempty"`
+}
+
+// ToolDisplayConfig is the per-tool display override inside a server's
+// config entry.
+type ToolDisplayConfig struct {
+	DisplayName string              `json:"displayName,omitempty"`
+	SignalText  tools.LocalizedText `json:"signalText,omitempty"`
 }
 
 // TransportType represents the type of transport for an MCP server

--- a/pkg/mcp/config_test.go
+++ b/pkg/mcp/config_test.go
@@ -223,3 +223,62 @@ func TestGetTransportType(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadConfigDisplayMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".mcp.json")
+
+	configContent := `{
+  "mcpServers": {
+    "glt": {
+      "command": "glt-mcp",
+      "displayName": "Freight Tools",
+      "signalText": {
+        "en": "Checking freight information",
+        "pt-BR": "Consultando informações de frete"
+      },
+      "tools": {
+        "glt_get_rates": {
+          "displayName": "Get Rates",
+          "signalText": "Checking rates"
+        }
+      }
+    },
+    "plain": {
+      "command": "plain-mcp"
+    }
+  }
+}`
+
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	glt := config.McpServers["glt"]
+	if glt.DisplayName != "Freight Tools" {
+		t.Errorf("DisplayName = %q, want 'Freight Tools'", glt.DisplayName)
+	}
+	if got := glt.SignalText.Resolve("pt-BR"); got != "Consultando informações de frete" {
+		t.Errorf("server SignalText pt-BR = %q", got)
+	}
+	override, ok := glt.Tools["glt_get_rates"]
+	if !ok {
+		t.Fatal("glt_get_rates override missing")
+	}
+	if override.DisplayName != "Get Rates" {
+		t.Errorf("tool DisplayName = %q", override.DisplayName)
+	}
+	if got := override.SignalText.Resolve("pt-BR"); got != "Checking rates" {
+		t.Errorf("tool SignalText = %q, want plain string for any locale", got)
+	}
+
+	plain := config.McpServers["plain"]
+	if plain.DisplayName != "" || !plain.SignalText.IsZero() || len(plain.Tools) != 0 {
+		t.Errorf("server without display metadata must stay zero: %+v", plain)
+	}
+}

--- a/pkg/mcp/protocol.go
+++ b/pkg/mcp/protocol.go
@@ -105,6 +105,7 @@ type ServerInfo struct {
 // Tool represents an MCP tool definition
 type Tool struct {
 	Name        string     `json:"name"`
+	Title       string     `json:"title,omitempty"`
 	Description string     `json:"description,omitempty"`
 	InputSchema ToolSchema `json:"inputSchema"`
 }

--- a/pkg/mcp/tools_meta_test.go
+++ b/pkg/mcp/tools_meta_test.go
@@ -1,0 +1,82 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/kcaldas/genie/pkg/tools"
+)
+
+func TestClientToolsMeta(t *testing.T) {
+	config := &Config{McpServers: map[string]ServerConfig{
+		"glt": {
+			Command:     "glt-mcp",
+			DisplayName: "Freight Tools",
+			SignalText:  tools.LocalizedText{Default: "Checking freight information"},
+			Tools: map[string]ToolDisplayConfig{
+				"glt_get_rates": {
+					DisplayName: "Get Rates",
+					SignalText:  tools.LocalizedText{Default: "Checking rates"},
+				},
+			},
+		},
+		"bare": {Command: "bare-mcp"},
+	}}
+
+	client := NewClient(config)
+	client.tools = map[string]*MCPTool{
+		"glt_get_rates": {
+			mcpTool:    Tool{Name: "glt_get_rates"},
+			serverName: "glt",
+			client:     client,
+		},
+		"glt_list_loads": {
+			mcpTool:    Tool{Name: "glt_list_loads", Title: "List Loads"},
+			serverName: "glt",
+			client:     client,
+		},
+		"bare_tool": {
+			mcpTool:    Tool{Name: "bare_tool"},
+			serverName: "bare",
+			client:     client,
+		},
+	}
+
+	meta := client.ToolsMeta()
+	if len(meta) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(meta))
+	}
+
+	// Per-tool config override wins over everything.
+	rates := meta["glt_get_rates"]
+	if rates.Server != "glt" || rates.ServerDisplayName != "Freight Tools" {
+		t.Errorf("server attribution wrong: %+v", rates)
+	}
+	if rates.DisplayName != "Get Rates" {
+		t.Errorf("DisplayName = %q, want config override", rates.DisplayName)
+	}
+	if got := rates.SignalText.Resolve(""); got != "Checking rates" {
+		t.Errorf("SignalText = %q, want per-tool override", got)
+	}
+
+	// No per-tool config: server-advertised title + server-level signal text.
+	loads := meta["glt_list_loads"]
+	if loads.DisplayName != "List Loads" {
+		t.Errorf("DisplayName = %q, want server-advertised title", loads.DisplayName)
+	}
+	if got := loads.SignalText.Resolve(""); got != "Checking freight information" {
+		t.Errorf("SignalText = %q, want server-level text", got)
+	}
+
+	// No config at all: attribution only, everything else zero.
+	bare := meta["bare_tool"]
+	if bare.Server != "bare" || bare.ServerDisplayName != "" || bare.DisplayName != "" || !bare.SignalText.IsZero() {
+		t.Errorf("bare tool meta must be attribution-only: %+v", bare)
+	}
+}
+
+func TestRegistryMCPToolsMetaWithoutClient(t *testing.T) {
+	registry := tools.NewRegistry()
+	if meta := registry.MCPToolsMeta(); len(meta) != 0 {
+		t.Fatalf("registry without MCP client must return empty meta, got %v", meta)
+	}
+}

--- a/pkg/prompts/loader_toolset_test.go
+++ b/pkg/prompts/loader_toolset_test.go
@@ -75,6 +75,10 @@ func (m *MockRegistry) MCPServerErrors() map[string]string {
 	return map[string]string{}
 }
 
+func (m *MockRegistry) MCPToolsMeta() map[string]tools.MCPToolMeta {
+	return map[string]tools.MCPToolMeta{}
+}
+
 func (m *MockRegistry) Shutdown() {}
 
 func TestAddToolsWithToolSets(t *testing.T) {

--- a/pkg/tools/mcp_meta.go
+++ b/pkg/tools/mcp_meta.go
@@ -1,0 +1,105 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// LocalizedText is owner-authored display text that accepts either a plain
+// JSON string or an object keyed by BCP-47 locale tags:
+//
+//	"signalText": "Checking rates"
+//	"signalText": {"en": "Checking rates", "pt-BR": "Consultando tarifas"}
+type LocalizedText struct {
+	// Default holds the text when it was configured as a plain string.
+	Default string
+	// Locales holds the per-locale texts when configured as an object.
+	Locales map[string]string
+}
+
+func (t *LocalizedText) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*t = LocalizedText{Default: s}
+		return nil
+	}
+	var m map[string]string
+	if err := json.Unmarshal(data, &m); err != nil {
+		return fmt.Errorf("localized text must be a string or an object of locale tag to string")
+	}
+	*t = LocalizedText{Locales: m}
+	return nil
+}
+
+// IsZero reports whether no text is configured at all.
+func (t LocalizedText) IsZero() bool {
+	return t.Default == "" && len(t.Locales) == 0
+}
+
+// Resolve picks the best text for a BCP-47 locale tag: exact match, then
+// same-language match, then English, then the plain-string default, then
+// the first entry by sorted key. Matching is case-insensitive and treats
+// underscores as hyphens ("pt_BR" matches "pt-BR"). Empty when nothing is
+// configured.
+func (t LocalizedText) Resolve(locale string) string {
+	if len(t.Locales) == 0 {
+		return t.Default
+	}
+
+	keys := make([]string, 0, len(t.Locales))
+	for k := range t.Locales {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	first := func(match func(key string) bool) string {
+		for _, k := range keys {
+			if match(normalizeLocale(k)) && strings.TrimSpace(t.Locales[k]) != "" {
+				return t.Locales[k]
+			}
+		}
+		return ""
+	}
+
+	if want := normalizeLocale(locale); want != "" {
+		if v := first(func(k string) bool { return k == want }); v != "" {
+			return v
+		}
+		lang := strings.SplitN(want, "-", 2)[0]
+		if v := first(func(k string) bool { return k == lang || strings.HasPrefix(k, lang+"-") }); v != "" {
+			return v
+		}
+	}
+	if v := first(func(k string) bool { return k == "en" || strings.HasPrefix(k, "en-") }); v != "" {
+		return v
+	}
+	if t.Default != "" {
+		return t.Default
+	}
+	return first(func(string) bool { return true })
+}
+
+func normalizeLocale(tag string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(tag), "_", "-"))
+}
+
+// MCPToolMeta is the display metadata for one MCP-discovered tool,
+// assembled from the server's .mcp.json entry and the tool definition the
+// server advertised.
+type MCPToolMeta struct {
+	// Server is the .mcp.json key of the server providing the tool.
+	Server string
+	// ServerDisplayName is the configured human-readable server name;
+	// empty when the config does not provide one.
+	ServerDisplayName string
+	// DisplayName is the per-tool display name: the config override when
+	// present, otherwise the title the server advertised. Never used for
+	// progress signals — those show SignalText or the raw tool name.
+	DisplayName string
+	// SignalText is the configured progress text: the per-tool text when
+	// present, otherwise the server-level text. Zero when neither is
+	// configured.
+	SignalText LocalizedText
+}

--- a/pkg/tools/mcp_meta_test.go
+++ b/pkg/tools/mcp_meta_test.go
@@ -1,0 +1,91 @@
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestLocalizedTextUnmarshalString(t *testing.T) {
+	var lt LocalizedText
+	if err := json.Unmarshal([]byte(`"Checking rates"`), &lt); err != nil {
+		t.Fatalf("unmarshal string: %v", err)
+	}
+	if lt.Default != "Checking rates" || len(lt.Locales) != 0 {
+		t.Fatalf("unexpected value: %+v", lt)
+	}
+	if lt.IsZero() {
+		t.Fatal("non-empty text reported zero")
+	}
+}
+
+func TestLocalizedTextUnmarshalMap(t *testing.T) {
+	var lt LocalizedText
+	data := `{"en": "Checking rates", "pt-BR": "Consultando tarifas"}`
+	if err := json.Unmarshal([]byte(data), &lt); err != nil {
+		t.Fatalf("unmarshal map: %v", err)
+	}
+	if lt.Default != "" || len(lt.Locales) != 2 {
+		t.Fatalf("unexpected value: %+v", lt)
+	}
+	if lt.Locales["pt-BR"] != "Consultando tarifas" {
+		t.Fatalf("unexpected pt-BR value: %q", lt.Locales["pt-BR"])
+	}
+}
+
+func TestLocalizedTextUnmarshalInvalid(t *testing.T) {
+	var lt LocalizedText
+	if err := json.Unmarshal([]byte(`42`), &lt); err == nil {
+		t.Fatal("expected error for non-string, non-object value")
+	}
+}
+
+func TestLocalizedTextIsZero(t *testing.T) {
+	if !(LocalizedText{}).IsZero() {
+		t.Fatal("empty value must be zero")
+	}
+	if (LocalizedText{Locales: map[string]string{"en": "x"}}).IsZero() {
+		t.Fatal("locale map must not be zero")
+	}
+}
+
+func TestLocalizedTextResolve(t *testing.T) {
+	mapped := LocalizedText{Locales: map[string]string{
+		"en":    "Checking rates",
+		"pt-BR": "Consultando tarifas",
+		"fr":    "Vérification des tarifs",
+	}}
+
+	tests := []struct {
+		name   string
+		text   LocalizedText
+		locale string
+		want   string
+	}{
+		{"plain string ignores locale", LocalizedText{Default: "Working"}, "pt-BR", "Working"},
+		{"exact match", mapped, "pt-BR", "Consultando tarifas"},
+		{"exact match is case-insensitive", mapped, "PT-br", "Consultando tarifas"},
+		{"underscore tag matches hyphen key", mapped, "pt_BR", "Consultando tarifas"},
+		{"language-prefix match", mapped, "pt", "Consultando tarifas"},
+		{"regional variant falls back to language", mapped, "fr-CA", "Vérification des tarifs"},
+		{"unknown locale falls back to en", mapped, "de", "Checking rates"},
+		{"empty locale falls back to en", mapped, "", "Checking rates"},
+		{"zero value resolves empty", LocalizedText{}, "en", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.text.Resolve(tt.locale); got != tt.want {
+				t.Fatalf("Resolve(%q) = %q, want %q", tt.locale, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocalizedTextResolveNoEnglishFallsBackToFirstSortedKey(t *testing.T) {
+	lt := LocalizedText{Locales: map[string]string{
+		"pt-BR": "Consultando tarifas",
+		"es":    "Consultando tarifas (es)",
+	}}
+	if got := lt.Resolve("de"); got != "Consultando tarifas (es)" {
+		t.Fatalf("Resolve(de) = %q, want first sorted entry", got)
+	}
+}

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -45,6 +45,10 @@ type Registry interface {
 	// servers connected or no MCP client is configured.
 	MCPServerErrors() map[string]string
 
+	// MCPToolsMeta returns display metadata for every MCP-discovered tool,
+	// keyed by tool name. Empty when no MCP client is configured.
+	MCPToolsMeta() map[string]MCPToolMeta
+
 	// Shutdown releases external resources owned by the registry:
 	// background PTY/process sessions and MCP server subprocesses.
 	// Without it, quitting Genie orphans those processes.
@@ -160,6 +164,9 @@ type MCPClient interface {
 	// ServerErrors returns the last connection error per configured server
 	// that failed to connect, keyed by server name.
 	ServerErrors() map[string]string
+	// ToolsMeta returns display metadata per discovered tool, keyed by
+	// tool name.
+	ToolsMeta() map[string]MCPToolMeta
 }
 
 // Register adds a tool to the registry
@@ -346,6 +353,17 @@ func (r *DefaultRegistry) MCPServerErrors() map[string]string {
 		return map[string]string{}
 	}
 	return r.mcpClient.ServerErrors()
+}
+
+// MCPToolsMeta returns per-tool display metadata from the MCP client.
+func (r *DefaultRegistry) MCPToolsMeta() map[string]MCPToolMeta {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	if r.mcpClient == nil {
+		return map[string]MCPToolMeta{}
+	}
+	return r.mcpClient.ToolsMeta()
 }
 
 // Shutdown releases external resources owned by the registry:

--- a/pkg/tools/registry_shadowing_test.go
+++ b/pkg/tools/registry_shadowing_test.go
@@ -35,7 +35,8 @@ func (f *fakeMCPClient) GetTools() []Tool             { return f.tools }
 func (f *fakeMCPClient) GetToolsByServer() map[string][]Tool {
 	return map[string][]Tool{"srv": f.tools}
 }
-func (f *fakeMCPClient) ServerErrors() map[string]string { return nil }
+func (f *fakeMCPClient) ServerErrors() map[string]string   { return nil }
+func (f *fakeMCPClient) ToolsMeta() map[string]MCPToolMeta { return nil }
 
 // A malicious or misconfigured MCP server must not be able to replace
 // built-in tools like bash or writeFile by advertising a tool with the

--- a/pkg/tools/registry_toolset_test.go
+++ b/pkg/tools/registry_toolset_test.go
@@ -225,3 +225,7 @@ func (m *MockMCPClient) Init(workingDir string) error {
 func (m *MockMCPClient) ServerErrors() map[string]string {
 	return map[string]string{}
 }
+
+func (m *MockMCPClient) ToolsMeta() map[string]MCPToolMeta {
+	return map[string]MCPToolMeta{}
+}


### PR DESCRIPTION
## Why

Mutiro surfaces MCP tool activity to end consumers (progress signals) and to owners (tools management screen). Today MCP tools reach hosts as bare names: signals show raw identifiers like `glt_get_rates`, and every server's tools collapse into one flat bucket because nothing downstream knows which server provided which tool — even though the MCP client tracks it.

Design doc: `mutiro/docs/plans/mcp-tool-display-metadata.md`.

## What

**`.mcp.json` server entries accept display metadata** (extension fields; other readers of the shared format ignore them):

```json
{
  "mcpServers": {
    "glt": {
      "command": "glt-mcp",
      "displayName": "Freight Tools",
      "signalText": {
        "en": "Checking freight information",
        "pt-BR": "Consultando informações de frete"
      },
      "tools": {
        "glt_get_rates": { "displayName": "Get Rates", "signalText": "Checking rates" }
      }
    }
  }
}
```

- `LocalizedText` accepts a plain string or a BCP-47 locale map. `Resolve(locale)`: exact match → same language → English → plain default → first sorted entry. Case-insensitive, `pt_BR` matches `pt-BR`.
- The MCP spec's tool `title` is now captured and used as the display-name fallback when config provides none.
- `Registry`/`MCPClient` gain `MCPToolsMeta() map[string]MCPToolMeta` — per-tool `Server`, `ServerDisplayName`, `DisplayName`, `SignalText`, flattened with per-tool config winning over server-level.

Hosts decide what to do with the metadata; Genie only carries it. Unconfigured tools keep resolving to empty metadata, so nothing changes for existing setups.

## Tests

- `LocalizedText` unmarshalling (string, map, invalid) and full `Resolve` fallback chain
- Config parsing of `displayName`/`signalText`/per-tool overrides, zero-value for servers without metadata
- `Client.ToolsMeta()` precedence: per-tool override > server-level; title fallback; attribution-only for bare servers
- `go test ./...` green, `golangci-lint` clean