### PR TITLE
feat(ctx): agent-wide shared context — <genie home>/.genie/AGENTS.md

### DIFF
--- a/pkg/ctx/project_context_part_provider.go
+++ b/pkg/ctx/project_context_part_provider.go
@@ -42,7 +42,21 @@ func (m *projectContextPartsProvider) SetTokenBudget(int) {}
 // GetPart returns the concatenated project context
 func (m *projectContextPartsProvider) GetPart(ctx context.Context) (ContextPart, error) {
 	var contents []string
+	var sharedContextPath string
 	var cwdContextPath string
+
+	// Agent-wide shared context: <genie home>/.genie/AGENTS.md loads for
+	// every working directory, before the workspace's own context file
+	// (general before specific). This is the always-on layer between the
+	// persona and per-workspace context: workspaces each load their own
+	// GENIE/CLAUDE/AGENTS.md, and this file is the one all of them share.
+	if home, ok := toolctx.GenieHome(ctx); ok {
+		content, contextPath := m.getCachedSharedContext(home)
+		if content != "" {
+			contents = append(contents, content)
+			sharedContextPath = contextPath
+		}
+	}
 
 	// Extract cwd from context and get its context file
 	cwd, ok := toolctx.WorkingDir(ctx)
@@ -54,10 +68,11 @@ func (m *projectContextPartsProvider) GetPart(ctx context.Context) (ContextPart,
 		}
 	}
 
-	// Add all collected context files from tool executions (excluding CWD context)
+	// Add all collected context files from tool executions (excluding the
+	// always-loaded shared and CWD context files)
 	m.mu.RLock()
 	for path, content := range m.contextFiles {
-		if path != cwdContextPath { // Avoid duplicating CWD context
+		if path != cwdContextPath && path != sharedContextPath {
 			contents = append(contents, content)
 		}
 	}
@@ -78,6 +93,29 @@ func (m *projectContextPartsProvider) GetPart(ctx context.Context) (ContextPart,
 // ClearPart is a no-op for project context (read-only)
 func (m *projectContextPartsProvider) ClearPart() error {
 	return nil
+}
+
+// getCachedSharedContext gets or reads the agent-wide shared context file
+// (<genie home>/.genie/AGENTS.md) and caches it, returns content and path
+func (m *projectContextPartsProvider) getCachedSharedContext(home string) (string, string) {
+	sharedPath := filepath.Join(home, ".genie", "AGENTS.md")
+
+	m.mu.RLock()
+	content, exists := m.contextFiles[sharedPath]
+	m.mu.RUnlock()
+	if exists {
+		return content, sharedPath
+	}
+
+	fileContent, err := os.ReadFile(sharedPath)
+	if err != nil {
+		return "", sharedPath
+	}
+	contentStr := string(fileContent)
+	m.mu.Lock()
+	m.contextFiles[sharedPath] = contentStr
+	m.mu.Unlock()
+	return contentStr, sharedPath
 }
 
 // getCachedCwdContext gets or reads CWD context file and caches it, returns content and path

--- a/pkg/ctx/project_context_part_provider_test.go
+++ b/pkg/ctx/project_context_part_provider_test.go
@@ -596,3 +596,82 @@ func TestProjectCtxManager_ReadsAgentsMdFromFileDirectory_OnReadFileExecution(t 
 	assert.NoError(t, err)
 	assert.Contains(t, part.Content, agentsMdContent)
 }
+
+func TestProjectCtxManager_SharedAgentContextFromGenieHome(t *testing.T) {
+	// <genie-home>/.genie/AGENTS.md is the agent-wide shared context: it
+	// loads for every workspace, before the workspace's own context file.
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".genie"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".genie", "AGENTS.md"), []byte("# Shared desk rules"), 0o644))
+
+	workspace := filepath.Join(home, "users", "alice")
+	require.NoError(t, os.MkdirAll(workspace, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, "AGENTS.md"), []byte("# Alice rules"), 0o644))
+
+	manager := NewProjectCtxManager(nil)
+	ctx := toolctx.WithGenieHome(context.Background(), home)
+	ctx = toolctx.WithWorkingDir(ctx, workspace)
+
+	part, err := manager.GetPart(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, part.Content, "# Shared desk rules")
+	assert.Contains(t, part.Content, "# Alice rules")
+	sharedIdx := strings.Index(part.Content, "# Shared desk rules")
+	aliceIdx := strings.Index(part.Content, "# Alice rules")
+	assert.Less(t, sharedIdx, aliceIdx, "shared context must precede workspace context (general before specific)")
+}
+
+func TestProjectCtxManager_SharedContextLoadsAtHomeRootToo(t *testing.T) {
+	// Owner conversations run at the genie home itself: the shared file and
+	// the root AGENTS.md (owner-only context) both load, exactly once each.
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".genie"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".genie", "AGENTS.md"), []byte("# Shared desk rules"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(home, "AGENTS.md"), []byte("# Owner-only context"), 0o644))
+
+	manager := NewProjectCtxManager(nil)
+	ctx := toolctx.WithGenieHome(context.Background(), home)
+	ctx = toolctx.WithWorkingDir(ctx, home)
+
+	part, err := manager.GetPart(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(part.Content, "# Shared desk rules"))
+	assert.Equal(t, 1, strings.Count(part.Content, "# Owner-only context"))
+}
+
+func TestProjectCtxManager_NoSharedFileUnchangedBehavior(t *testing.T) {
+	home := t.TempDir()
+	workspace := filepath.Join(home, "users", "bob")
+	require.NoError(t, os.MkdirAll(workspace, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workspace, "GENIE.md"), []byte("# Bob genie"), 0o644))
+
+	manager := NewProjectCtxManager(nil)
+	ctx := toolctx.WithGenieHome(context.Background(), home)
+	ctx = toolctx.WithWorkingDir(ctx, workspace)
+
+	part, err := manager.GetPart(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "# Bob genie", part.Content)
+}
+
+func TestProjectCtxManager_SharedContextNotDuplicatedByToolRead(t *testing.T) {
+	// If the agent reads .genie/AGENTS.md through the read tool, the
+	// collected copy must not duplicate the always-loaded shared part.
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".genie"), 0o755))
+	sharedPath := filepath.Join(home, ".genie", "AGENTS.md")
+	require.NoError(t, os.WriteFile(sharedPath, []byte("# Shared desk rules"), 0o644))
+
+	manager := NewProjectCtxManager(nil).(*projectContextPartsProvider)
+	manager.handleToolExecutedEvent(events.ToolExecutedEvent{
+		ToolName:   "readFile",
+		Parameters: map[string]any{"file_path": sharedPath},
+		Result:     map[string]any{"results": "# Shared desk rules"},
+	})
+
+	ctx := toolctx.WithGenieHome(context.Background(), home)
+	ctx = toolctx.WithWorkingDir(ctx, home)
+	part, err := manager.GetPart(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(part.Content, "# Shared desk rules"))
+}


### PR DESCRIPTION
Adds the missing context layer between the persona and per-workspace context files.

Today each working directory loads its own `GENIE.md`/`CLAUDE.md`/`AGENTS.md`, but an agent whose conversations run in per-user workspaces has no file shared by all of them — cross-workspace rules end up crammed into the persona/instructions. Found operating a production multi-user agent (Mutiro freight desk): rules placed in one user's workspace file silently never applied to email-triggered turns running in a different workspace.

`<genie home>/.genie/AGENTS.md` now loads for every working directory, prepended before the CWD's own context file (general → specific). Design points:

- The path never collides with the CWD chain, so root `AGENTS.md` keeps its current meaning (context for conversations at the home itself — for Mutiro, the owner's workspace) and per-workspace files are untouched.
- Home comes from the context (`toolctx.GenieHome`), already plumbed.
- Cached like the CWD file; tool-read copies of the same path are deduped.
- No file → behavior identical to today (covered by test).

Mirrors `.genie/skills`: skills are what the agent can do everywhere; this file is what it knows everywhere.