### PR TITLE
viewDocument: anthropic document blocks + Word .docx extraction

### DIFF
--- a/pkg/llm/anthropic/client_test.go
+++ b/pkg/llm/anthropic/client_test.go
@@ -223,6 +223,93 @@ func TestClient_GenerateContent_WithToolCall(t *testing.T) {
 	assert.Equal(t, "call_1", last.Content[0].OfToolResult.ToolUseID)
 }
 
+func TestClient_GenerateContent_ViewDocumentAttachesDocumentBlock(t *testing.T) {
+	pdfData := []byte("%PDF-1.4 fake document body")
+	encoded := base64.StdEncoding.EncodeToString(pdfData)
+	toolInput := json.RawMessage(`{"file_path":"report.pdf","_display_message":"reading the report"}`)
+	mockAPI := &mockMessageClient{
+		t: t,
+		responses: []*anthropic_sdk.Message{
+			{
+				ID:         "call",
+				Content:    []anthropic_sdk.ContentBlockUnion{{Type: "tool_use", ID: "call_1", Name: "viewDocument", Input: toolInput}},
+				Model:      anthropic_sdk.Model("claude-3-5-sonnet-20241022"),
+				Role:       constant.Assistant(""),
+				StopReason: anthropic_sdk.StopReasonToolUse,
+				Type:       constant.Message(""),
+			},
+			newTextMessage("final", "Summarised the report."),
+		},
+	}
+
+	rawClient, err := NewClient(&events.NoOpEventBus{}, WithMessageClient(mockAPI))
+	require.NoError(t, err)
+	client := rawClient.(*Client)
+
+	prompt := ai.Prompt{
+		Name:      "docs",
+		Text:      "Summarise report.pdf",
+		ModelName: "claude-3-5-sonnet-20241022",
+		MaxTokens: 256,
+		Functions: []*ai.FunctionDeclaration{
+			{
+				Name:        "viewDocument",
+				Description: "Reads a document",
+				Parameters: &ai.Schema{
+					Type: ai.TypeObject,
+					Properties: map[string]*ai.Schema{
+						"file_path": {Type: ai.TypeString},
+					},
+					Required: []string{"file_path"},
+				},
+			},
+		},
+		Handlers: map[string]ai.HandlerFunc{
+			"viewDocument": func(ctx context.Context, args map[string]any) (map[string]any, error) {
+				return map[string]any{
+					"success":     true,
+					"mime_type":   "application/pdf",
+					"size_bytes":  int64(len(pdfData)),
+					"data_base64": encoded,
+					"data_url":    "data:application/pdf;base64," + encoded,
+					"path":        "report.pdf",
+				}, nil
+			},
+		},
+	}
+
+	resp, err := client.GenerateContent(context.Background(), prompt, false)
+	require.NoError(t, err)
+	assert.Equal(t, "Summarised the report.", resp)
+
+	mockAPI.mu.Lock()
+	defer mockAPI.mu.Unlock()
+	require.GreaterOrEqual(t, len(mockAPI.requests), 2)
+	second := mockAPI.requests[1]
+	require.GreaterOrEqual(t, len(second.Messages), 3)
+
+	toolMsg := second.Messages[len(second.Messages)-2]
+	require.Equal(t, anthropic_sdk.MessageParamRoleUser, toolMsg.Role)
+	require.NotNil(t, toolMsg.Content[0].OfToolResult)
+	assert.Equal(t, "call_1", toolMsg.Content[0].OfToolResult.ToolUseID)
+	resultJSON, err := json.Marshal(toolMsg.Content[0].OfToolResult)
+	require.NoError(t, err)
+	assert.NotContains(t, string(resultJSON), encoded,
+		"tool_result must not carry the base64 payload as text")
+
+	docMsg := second.Messages[len(second.Messages)-1]
+	require.Equal(t, anthropic_sdk.MessageParamRoleUser, docMsg.Role)
+	var docBlock *anthropic_sdk.DocumentBlockParam
+	for _, block := range docMsg.Content {
+		if block.OfDocument != nil {
+			docBlock = block.OfDocument
+		}
+	}
+	require.NotNil(t, docBlock, "expected a document block message after the tool result")
+	require.NotNil(t, docBlock.Source.OfBase64)
+	assert.Equal(t, encoded, docBlock.Source.OfBase64.Data)
+}
+
 func TestClient_CountTokens(t *testing.T) {
 	mockAPI := &mockMessageClient{
 		t:             t,

--- a/pkg/llm/anthropic/turn.go
+++ b/pkg/llm/anthropic/turn.go
@@ -204,13 +204,13 @@ func (t *turnState) recordAssistantStep(message anthropic_sdk.MessageParam, tool
 }
 
 // AddToolResults converts executed tool results into a tool_result user
-// message correlated by tool_use ID (plus any image payloads, which
-// follow as separate user messages).
+// message correlated by tool_use ID (plus any image or document
+// payloads, which follow as separate user messages).
 func (t *turnState) AddToolResults(ctx context.Context, results []llmshared.ToolResult) error {
 	c := t.client
 
 	toolResultBlocks := make([]anthropic_sdk.ContentBlockParamUnion, 0, len(results))
-	var imageMessages []anthropic_sdk.MessageParam
+	var mediaMessages []anthropic_sdk.MessageParam
 
 	for _, res := range results {
 		result := res.Result
@@ -227,7 +227,8 @@ func (t *turnState) AddToolResults(ctx context.Context, results []llmshared.Tool
 			}
 		}
 
-		if res.Call.Name == "viewImage" {
+		switch res.Call.Name {
+		case "viewImage":
 			img, sanitized, err := toolpayload.Extract(result)
 			if err != nil {
 				return fmt.Errorf("invalid viewImage response: %w", err)
@@ -239,7 +240,24 @@ func (t *turnState) AddToolResults(ctx context.Context, results []llmshared.Tool
 					blocks = append(blocks, anthropic_sdk.NewTextBlock(fmt.Sprintf("Image retrieved from %s", text)))
 				}
 				blocks = append(blocks, anthropic_sdk.NewImageBlockBase64(img.MIMEType, img.Base64Data))
-				imageMessages = append(imageMessages, anthropic_sdk.NewUserMessage(blocks...))
+				mediaMessages = append(mediaMessages, anthropic_sdk.NewUserMessage(blocks...))
+			}
+		case "viewDocument":
+			doc, sanitized, err := toolpayload.Extract(result)
+			if err != nil {
+				return fmt.Errorf("invalid viewDocument response: %w", err)
+			}
+			result = sanitized
+			// The Messages API only accepts PDFs as base64 document
+			// blocks; other formats reach the model as text content in
+			// the tool result itself.
+			if doc != nil && doc.MIMEType == "application/pdf" {
+				blocks := []anthropic_sdk.ContentBlockParamUnion{}
+				if text := toolpayload.SanitizePath(doc.Path); text != "" {
+					blocks = append(blocks, anthropic_sdk.NewTextBlock(fmt.Sprintf("Document retrieved from %s", text)))
+				}
+				blocks = append(blocks, anthropic_sdk.NewDocumentBlock(anthropic_sdk.Base64PDFSourceParam{Data: doc.Base64Data}))
+				mediaMessages = append(mediaMessages, anthropic_sdk.NewUserMessage(blocks...))
 			}
 		}
 
@@ -254,7 +272,7 @@ func (t *turnState) AddToolResults(ctx context.Context, results []llmshared.Tool
 	if len(toolResultBlocks) > 0 {
 		t.messages = append(t.messages, anthropic_sdk.NewUserMessage(toolResultBlocks...))
 	}
-	t.messages = append(t.messages, imageMessages...)
+	t.messages = append(t.messages, mediaMessages...)
 	return nil
 }
 

--- a/pkg/llm/shared/toolpayload/toolpayload.go
+++ b/pkg/llm/shared/toolpayload/toolpayload.go
@@ -50,6 +50,12 @@ func Extract(input map[string]any) (*Payload, map[string]any, error) {
 	if !ok || base64Str == "" {
 		delete(sanitized, "data_base64")
 		delete(sanitized, "data_url")
+		// Text-form results (e.g. viewDocument on a .docx) carry their
+		// extracted content in the tool result itself; there is no
+		// binary payload to attach.
+		if content, ok := input["content"].(string); ok && strings.TrimSpace(content) != "" {
+			return nil, sanitized, nil
+		}
 		return nil, sanitized, fmt.Errorf("missing base64-encoded payload")
 	}
 

--- a/pkg/llm/shared/toolpayload/toolpayload_test.go
+++ b/pkg/llm/shared/toolpayload/toolpayload_test.go
@@ -1,0 +1,51 @@
+package toolpayload
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtract_BinaryPayload(t *testing.T) {
+	data := []byte("%PDF-1.4 body")
+	encoded := base64.StdEncoding.EncodeToString(data)
+
+	payload, sanitized, err := Extract(map[string]any{
+		"success":     true,
+		"mime_type":   "application/pdf",
+		"size_bytes":  int64(len(data)),
+		"data_base64": encoded,
+		"data_url":    "data:application/pdf;base64," + encoded,
+		"path":        "report.pdf",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, payload)
+	assert.Equal(t, data, payload.Data)
+	assert.Equal(t, "application/pdf", payload.MIMEType)
+	assert.NotContains(t, sanitized, "data_base64")
+	assert.NotContains(t, sanitized, "data_url")
+}
+
+func TestExtract_TextOnlyResult(t *testing.T) {
+	payload, sanitized, err := Extract(map[string]any{
+		"success":   true,
+		"mime_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"content":   "# Coversheet\n\nHello world.",
+		"path":      "report.docx",
+	})
+	require.NoError(t, err, "text-form results carry their content in the tool result and have no binary payload")
+	assert.Nil(t, payload)
+	assert.Equal(t, "# Coversheet\n\nHello world.", sanitized["content"])
+}
+
+func TestExtract_MissingPayloadStillErrors(t *testing.T) {
+	payload, _, err := Extract(map[string]any{
+		"success":   true,
+		"mime_type": "image/png",
+		"path":      "shot.png",
+	})
+	require.Error(t, err)
+	assert.Nil(t, payload)
+}

--- a/pkg/tools/docx.go
+++ b/pkg/tools/docx.go
@@ -1,0 +1,166 @@
+package tools
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// extractDocxMarkdown converts the main document part of a .docx archive
+// into markdown-ish text: headings, list items, tables, and plain
+// paragraphs. Formatting beyond that (bold, images, nested tables) is
+// dropped — the goal is readable content for the model, not fidelity.
+func extractDocxMarkdown(data []byte) (string, error) {
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", fmt.Errorf("not a valid docx archive: %w", err)
+	}
+	for _, f := range zr.File {
+		if f.Name != "word/document.xml" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return "", fmt.Errorf("failed to open document part: %w", err)
+		}
+		defer rc.Close()
+		return docxMarkdownFromXML(rc)
+	}
+	return "", fmt.Errorf("docx archive has no word/document.xml part")
+}
+
+func docxMarkdownFromXML(r io.Reader) (string, error) {
+	dec := xml.NewDecoder(r)
+
+	var (
+		out     strings.Builder
+		para    strings.Builder
+		cell    strings.Builder
+		row     []string
+		heading int
+		list    bool
+		inText  bool
+		inTable bool
+		tblRows int
+	)
+
+	// Runs land in the current table cell when inside a table, otherwise
+	// in the current paragraph.
+	target := func() *strings.Builder {
+		if inTable {
+			return &cell
+		}
+		return &para
+	}
+
+	flushPara := func() {
+		text := strings.TrimSpace(para.String())
+		para.Reset()
+		prefix := ""
+		switch {
+		case heading > 0:
+			prefix = strings.Repeat("#", min(heading, 6)) + " "
+		case list:
+			prefix = "- "
+		}
+		heading, list = 0, false
+		if text == "" {
+			return
+		}
+		out.WriteString(prefix)
+		out.WriteString(text)
+		out.WriteString("\n\n")
+	}
+
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to parse document part: %w", err)
+		}
+
+		switch el := tok.(type) {
+		case xml.StartElement:
+			switch el.Name.Local {
+			case "tbl":
+				inTable = true
+				tblRows = 0
+			case "tr":
+				row = row[:0]
+			case "tc":
+				cell.Reset()
+			case "pStyle":
+				if lvl := docxHeadingLevel(docxAttr(el, "val")); lvl > 0 {
+					heading = lvl
+				}
+			case "numPr":
+				list = true
+			case "t":
+				inText = true
+			case "tab":
+				target().WriteString("\t")
+			case "br", "cr":
+				target().WriteString("\n")
+			}
+		case xml.EndElement:
+			switch el.Name.Local {
+			case "t":
+				inText = false
+			case "p":
+				if inTable {
+					// Paragraph breaks inside a cell collapse to a space.
+					cell.WriteString(" ")
+				} else {
+					flushPara()
+				}
+			case "tc":
+				row = append(row, strings.TrimSpace(cell.String()))
+				cell.Reset()
+			case "tr":
+				out.WriteString("| " + strings.Join(row, " | ") + " |\n")
+				tblRows++
+				if tblRows == 1 {
+					out.WriteString("|" + strings.Repeat(" --- |", len(row)) + "\n")
+				}
+			case "tbl":
+				inTable = false
+				out.WriteString("\n")
+			}
+		case xml.CharData:
+			if inText {
+				target().Write(el)
+			}
+		}
+	}
+
+	flushPara()
+	return strings.TrimSpace(out.String()), nil
+}
+
+func docxHeadingLevel(style string) int {
+	s := strings.ToLower(strings.TrimSpace(style))
+	if s == "title" {
+		return 1
+	}
+	if rest, ok := strings.CutPrefix(s, "heading"); ok {
+		if n, err := strconv.Atoi(rest); err == nil && n >= 1 {
+			return n
+		}
+	}
+	return 0
+}
+
+func docxAttr(el xml.StartElement, local string) string {
+	for _, attr := range el.Attr {
+		if attr.Name.Local == local {
+			return attr.Value
+		}
+	}
+	return ""
+}

--- a/pkg/tools/view_document.go
+++ b/pkg/tools/view_document.go
@@ -16,13 +16,25 @@ import (
 
 const (
 	defaultMaxDocumentBytes = 20 * 1024 * 1024 // 20 MiB
+
+	mimeTypePDF  = "application/pdf"
+	mimeTypeDocx = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 )
 
 var allowedDocumentMIMETypes = map[string]struct{}{
-	"application/pdf": {},
+	mimeTypePDF:  {},
+	mimeTypeDocx: {},
 }
 
-// ViewDocumentTool exposes documents (currently PDFs) to the LLM.
+// documentMIMEByExtension pins the MIME type for supported extensions;
+// the system mime tables are not guaranteed to know them (a .docx sniffs
+// as application/zip) and hosted images may lack /etc/mime.types.
+var documentMIMEByExtension = map[string]string{
+	".pdf":  mimeTypePDF,
+	".docx": mimeTypeDocx,
+}
+
+// ViewDocumentTool exposes documents (PDF, Word .docx) to the LLM.
 type ViewDocumentTool struct {
 	publisher events.Publisher
 	maxBytes  int64
@@ -57,7 +69,7 @@ func NewViewDocumentTool(publisher events.Publisher, opts ...ViewDocumentOption)
 func (v *ViewDocumentTool) Declaration() *ai.FunctionDeclaration {
 	return &ai.FunctionDeclaration{
 		Name:        "viewDocument",
-		Description: "Reads a document from the workspace (currently only PDF) and returns it for inspection.",
+		Description: "Reads a document from the workspace (PDF or Word .docx) and returns it for inspection. PDFs are attached natively; .docx content comes back as extracted markdown text.",
 		Parameters: &ai.Schema{
 			Type:        ai.TypeObject,
 			Description: "Parameters required to view a document",
@@ -101,6 +113,10 @@ func (v *ViewDocumentTool) Declaration() *ai.FunctionDeclaration {
 					Type:        ai.TypeString,
 					Description: "Convenience data URL prefixed with the MIME type.",
 				},
+				"content": {
+					Type:        ai.TypeString,
+					Description: "Extracted document text (markdown). Present for formats returned as text, such as Word .docx.",
+				},
 				"error": {
 					Type:        ai.TypeString,
 					Description: "Reason for failure when success is false.",
@@ -140,6 +156,16 @@ func (v *ViewDocumentTool) Handler() ai.HandlerFunc {
 		}
 
 		relativePath := ConvertToRelativePath(ctx, resolvedPath)
+
+		if payload.text {
+			return map[string]any{
+				"success":    true,
+				"mime_type":  payload.mimeType,
+				"size_bytes": payload.size,
+				"content":    payload.content,
+				"path":       relativePath,
+			}, nil
+		}
 
 		return map[string]any{
 			"success":     true,
@@ -195,6 +221,22 @@ func (v *ViewDocumentTool) loadDocument(path string) (*documentPayload, error) {
 		return nil, fmt.Errorf("unsupported document type: %s", mimeType)
 	}
 
+	if mimeType == mimeTypeDocx {
+		content, err := extractDocxMarkdown(data)
+		if err != nil {
+			return nil, err
+		}
+		if content == "" {
+			content = "(document contains no extractable text)"
+		}
+		return &documentPayload{
+			content:  content,
+			text:     true,
+			mimeType: mimeType,
+			size:     size,
+		}, nil
+	}
+
 	return &documentPayload{
 		base64:   base64.StdEncoding.EncodeToString(data),
 		mimeType: mimeType,
@@ -203,7 +245,11 @@ func (v *ViewDocumentTool) loadDocument(path string) (*documentPayload, error) {
 }
 
 func detectDocumentMIME(path string, data []byte) string {
-	if ext := strings.ToLower(filepath.Ext(path)); ext != "" {
+	ext := strings.ToLower(filepath.Ext(path))
+	if typ, ok := documentMIMEByExtension[ext]; ok {
+		return typ
+	}
+	if ext != "" {
 		if typ := mime.TypeByExtension(ext); typ != "" {
 			return typ
 		}
@@ -237,6 +283,8 @@ func (v *ViewDocumentTool) failure(message string) (map[string]any, error) {
 
 type documentPayload struct {
 	base64   string
+	content  string
+	text     bool
 	mimeType string
 	size     int64
 }

--- a/pkg/tools/view_document_test.go
+++ b/pkg/tools/view_document_test.go
@@ -1,6 +1,8 @@
 package tools_test
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"encoding/base64"
 	"os"
@@ -64,6 +66,89 @@ func TestViewDocumentTool_Success(t *testing.T) {
 
 	formatted := tool.FormatOutput(result)
 	assert.Contains(t, formatted, "Attached document `doc.pdf`")
+}
+
+const sampleDocxDocumentXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Coversheet</w:t></w:r></w:p>
+    <w:p><w:r><w:t xml:space="preserve">Hello </w:t></w:r><w:r><w:t>world.</w:t></w:r></w:p>
+    <w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>First item</w:t></w:r></w:p>
+    <w:tbl>
+      <w:tr><w:tc><w:p><w:r><w:t>Name</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Value</w:t></w:r></w:p></w:tc></w:tr>
+      <w:tr><w:tc><w:p><w:r><w:t>Type</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>MI-15</w:t></w:r></w:p></w:tc></w:tr>
+    </w:tbl>
+  </w:body>
+</w:document>`
+
+func writeDocx(t *testing.T, path, documentXML string) {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	part, err := zw.Create("word/document.xml")
+	require.NoError(t, err)
+	_, err = part.Write([]byte(documentXML))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o600))
+}
+
+func TestViewDocumentTool_DocxReturnsMarkdown(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "report.docx")
+	writeDocx(t, filePath, sampleDocxDocumentXML)
+
+	ctx := toolctx.WithWorkingDir(context.Background(), tmpDir)
+	tool := tools.NewViewDocumentTool(&events.NoOpPublisher{})
+	handler := tool.Handler()
+
+	result, err := handler(ctx, map[string]any{
+		"file_path":        "report.docx",
+		"_display_message": "Reading the coversheet",
+	})
+	require.NoError(t, err)
+
+	require.True(t, result["success"].(bool), "expected success, got error: %v", result["error"])
+	assert.Equal(t, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", result["mime_type"])
+	assert.Equal(t, "report.docx", result["path"])
+
+	content, _ := result["content"].(string)
+	assert.Contains(t, content, "# Coversheet")
+	assert.Contains(t, content, "Hello world.")
+	assert.Contains(t, content, "- First item")
+	assert.Contains(t, content, "| Name | Value |")
+	assert.Contains(t, content, "| Type | MI-15 |")
+
+	_, hasBase64 := result["data_base64"]
+	_, hasDataURL := result["data_url"]
+	assert.False(t, hasBase64, "docx results must travel as text, not base64")
+	assert.False(t, hasDataURL, "docx results must travel as text, not a data URL")
+}
+
+func TestViewDocumentTool_DocxWithoutDocumentPart(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "broken.docx")
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	part, err := zw.Create("unrelated.txt")
+	require.NoError(t, err)
+	_, err = part.Write([]byte("not a word document"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, os.WriteFile(filePath, buf.Bytes(), 0o600))
+
+	ctx := toolctx.WithWorkingDir(context.Background(), tmpDir)
+	tool := tools.NewViewDocumentTool(&events.NoOpPublisher{})
+	handler := tool.Handler()
+
+	result, err := handler(ctx, map[string]any{
+		"file_path":        "broken.docx",
+		"_display_message": "Reading a broken file",
+	})
+	require.NoError(t, err)
+	assert.False(t, result["success"].(bool))
+	assert.Contains(t, result["error"], "word/document.xml")
 }
 
 func TestViewDocumentTool_PathOutsideWorkspace(t *testing.T) {


### PR DESCRIPTION
## What

Two fixes to `viewDocument` provider handling:

**anthropic: attach documents as native document blocks.** The anthropic turn handler only extracted `viewImage` payloads; a `viewDocument` result had its full base64 `data_url` JSON-marshaled into the `tool_result` text block — burning tokens as base64 text or blowing the context. PDFs are now extracted like the other providers do and attached as base64 document blocks after the sanitized tool result.

**tools: Word .docx support via markdown extraction.** No model reads .docx natively, so unlike PDFs the content travels as text. The main document part is unzipped and converted to markdown (headings, lists, tables, paragraphs) with the stdlib — no external converter or subprocess, works on every provider including local models. `toolpayload.Extract` recognises text-form results (`content` instead of `data_base64`) so providers pass the extracted text through as a plain tool result.

## Tests

- `TestClient_GenerateContent_ViewDocumentAttachesDocumentBlock` — asserts the document block message and that the tool_result no longer carries the base64 text
- `TestViewDocumentTool_DocxReturnsMarkdown` / `_DocxWithoutDocumentPart` — extraction happy path (heading, list, table) and malformed archive
- `toolpayload` unit tests for binary, text-form, and missing-payload results

Full suite green.