### PR TITLE
fix(ctx): read shared agent context at Start; never lose it silently

### DIFF
--- a/pkg/ctx/project_context_part_provider.go
+++ b/pkg/ctx/project_context_part_provider.go
@@ -2,6 +2,7 @@ package ctx
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -109,6 +110,12 @@ func (m *projectContextPartsProvider) getCachedSharedContext(home string) (strin
 
 	fileContent, err := os.ReadFile(sharedPath)
 	if err != nil {
+		if !os.IsNotExist(err) {
+			// The file is there but unreadable: without it the agent silently
+			// loses every agent-wide rule, so this must never fail quietly.
+			slog.Warn("shared agent context file could not be read; agent-wide rules will be missing from prompts",
+				"path", sharedPath, "error", err)
+		}
 		return "", sharedPath
 	}
 	contentStr := string(fileContent)

--- a/pkg/genie/core.go
+++ b/pkg/genie/core.go
@@ -307,6 +307,15 @@ func (g *core) Start(workingDir *string, persona *string, opts ...StartOption) (
 	}
 	g.initContextBudget(startCtx)
 
+	// Warm the context caches with the same guaranteed ctx that skills
+	// discovery gets: the agent-wide shared context (<home>/.genie/AGENTS.md)
+	// and the workspace context file are read and cached now, so a read
+	// failure at turn time (permissions, a stale mount) cannot silently
+	// strip agent-wide rules from prompts mid-session.
+	if _, err := g.contextMgr.GetContextParts(startCtx); err != nil {
+		slog.Warn("context warm-up at start failed; continuing with cold caches", "error", err)
+	}
+
 	// Return session directly - session.Session implements genie.Session
 	return sess, nil
 }

--- a/pkg/genie/shared_context_resilience_test.go
+++ b/pkg/genie/shared_context_resilience_test.go
@@ -1,0 +1,43 @@
+package genie_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kcaldas/genie/pkg/genie/genietest"
+)
+
+// TestSharedAgentContextSurvivesReadFailureAfterStart pins the resilience
+// contract of the agent-wide shared context file (<genie home>/.genie/AGENTS.md):
+// it must be read and cached at Start — the same moment skills are discovered —
+// so that a read failure at turn time (permissions, a stale FUSE mount, cwd
+// tricks) cannot silently strip agent-wide rules from the prompt. Skills
+// already behave this way (boot-time discovery, cached); the shared file must
+// match, or a hosted agent can lose its entire rulebook with no error anywhere.
+func TestSharedAgentContextSurvivesReadFailureAfterStart(t *testing.T) {
+	f := genietest.NewTestFixture(t)
+
+	genieDir := filepath.Join(f.TestDir, ".genie")
+	require.NoError(t, os.MkdirAll(genieDir, 0o755))
+	marker := "SHARED-CONTEXT-MARKER: no client quotation goes out without approval"
+	require.NoError(t, os.WriteFile(
+		filepath.Join(genieDir, "AGENTS.md"),
+		[]byte("# Desk Manual\n\n"+marker+"\n"), 0o644))
+
+	f.StartAndGetSession()
+
+	// Block reads after Start — the production suspicion for hosted pods.
+	sharedFile := filepath.Join(genieDir, "AGENTS.md")
+	require.NoError(t, os.Chmod(sharedFile, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(sharedFile, 0o644) })
+
+	parts, err := f.Genie.GetContext(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, parts["project"], marker,
+		"shared agent context read at Start must survive later read failures")
+}


### PR DESCRIPTION
The agent-wide shared context file (`<genie home>/.genie/AGENTS.md`) was read fresh on every turn and **silently dropped** from the prompt whenever the read failed — no log, no error, the agent just lost its entire rulebook mid-session. Skills never had this failure mode: they are discovered once at Start with a guaranteed-good ctx and cached.

This PR gives shared context the same contract:

- `core.Start` warms the context caches right after the budget is initialized — the shared file is read at the same reliable moment skills are discovered, and the existing cache-first lookup then serves it even if later reads fail (permissions, stale FUSE mounts, cwd surprises).
- A read failure of an *existing* shared file logs a warning instead of failing quietly.

Test: `TestSharedAgentContextSurvivesReadFailureAfterStart` — writes the shared file, starts the engine, chmods the file to 0000, and asserts the content still reaches the context. Red before this change, green after.

Found while chasing a production hosted agent that answered client emails without its desk rules while its skills kept working (mutirolabs/agents-armlog#14).