### PR TITLE
feat(ctx): user-tier shared context — $HOME/.genie/AGENTS.md loads for every session

### DIFF
--- a/pkg/ctx/project_context_part_provider.go
+++ b/pkg/ctx/project_context_part_provider.go
@@ -43,19 +43,38 @@ func (m *projectContextPartsProvider) SetTokenBudget(int) {}
 // GetPart returns the concatenated project context
 func (m *projectContextPartsProvider) GetPart(ctx context.Context) (ContextPart, error) {
 	var contents []string
+	var userContextPath string
 	var sharedContextPath string
 	var cwdContextPath string
+
+	// User-level shared context: $HOME/.genie/AGENTS.md loads for every
+	// session — the context twin of user-tier skills ($HOME/.genie/skills).
+	// Loads first: general before specific.
+	if userHome, err := os.UserHomeDir(); err == nil && userHome != "" {
+		content, contextPath := m.getCachedSharedFile(filepath.Join(userHome, ".genie", "AGENTS.md"))
+		userContextPath = contextPath
+		if content != "" {
+			contents = append(contents, content)
+		}
+	}
 
 	// Agent-wide shared context: <genie home>/.genie/AGENTS.md loads for
 	// every working directory, before the workspace's own context file
 	// (general before specific). This is the always-on layer between the
 	// persona and per-workspace context: workspaces each load their own
 	// GENIE/CLAUDE/AGENTS.md, and this file is the one all of them share.
+	// When HOME and genie home are the same directory (hosted agents point
+	// both at the state dir), the file loads exactly once.
 	if home, ok := toolctx.GenieHome(ctx); ok {
-		content, contextPath := m.getCachedSharedContext(home)
-		if content != "" {
-			contents = append(contents, content)
+		sharedPath := filepath.Join(home, ".genie", "AGENTS.md")
+		if sharedPath == userContextPath {
+			sharedContextPath = userContextPath
+		} else {
+			content, contextPath := m.getCachedSharedFile(sharedPath)
 			sharedContextPath = contextPath
+			if content != "" {
+				contents = append(contents, content)
+			}
 		}
 	}
 
@@ -73,7 +92,7 @@ func (m *projectContextPartsProvider) GetPart(ctx context.Context) (ContextPart,
 	// always-loaded shared and CWD context files)
 	m.mu.RLock()
 	for path, content := range m.contextFiles {
-		if path != cwdContextPath && path != sharedContextPath {
+		if path != cwdContextPath && path != sharedContextPath && path != userContextPath {
 			contents = append(contents, content)
 		}
 	}
@@ -96,11 +115,9 @@ func (m *projectContextPartsProvider) ClearPart() error {
 	return nil
 }
 
-// getCachedSharedContext gets or reads the agent-wide shared context file
-// (<genie home>/.genie/AGENTS.md) and caches it, returns content and path
-func (m *projectContextPartsProvider) getCachedSharedContext(home string) (string, string) {
-	sharedPath := filepath.Join(home, ".genie", "AGENTS.md")
-
+// getCachedSharedFile gets or reads a shared context file (a .genie/AGENTS.md
+// at the user home or the genie home) and caches it, returns content and path
+func (m *projectContextPartsProvider) getCachedSharedFile(sharedPath string) (string, string) {
 	m.mu.RLock()
 	content, exists := m.contextFiles[sharedPath]
 	m.mu.RUnlock()

--- a/pkg/ctx/user_shared_context_test.go
+++ b/pkg/ctx/user_shared_context_test.go
@@ -1,0 +1,69 @@
+package ctx
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kcaldas/genie/pkg/toolctx"
+)
+
+func writeAgentsMD(t *testing.T, root, content string) {
+	t.Helper()
+	dir := filepath.Join(root, ".genie")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(content), 0o644))
+}
+
+// TestUserTierSharedContext: $HOME/.genie/AGENTS.md is a shared-context
+// tier of its own, mirroring user-tier skills ($HOME/.genie/skills). It
+// loads for every session, before the agent-wide file (general before
+// specific). Hosted Mutiro agents rely on this symmetry: HOME points at
+// the agent state dir, so user-tier skills worked while the genie-home
+// tier was broken — context must resolve through the same tiers skills do.
+func TestUserTierSharedContext(t *testing.T) {
+	userHome := t.TempDir()
+	t.Setenv("HOME", userHome)
+	writeAgentsMD(t, userHome, "USER-TIER-MARKER rules\n")
+
+	agentHome := t.TempDir()
+	writeAgentsMD(t, agentHome, "PROJECT-TIER-MARKER rules\n")
+
+	provider := NewProjectCtxManager(nil)
+	ctx := toolctx.WithGenieHome(context.Background(), agentHome)
+	ctx = toolctx.WithWorkingDir(ctx, agentHome)
+
+	part, err := provider.GetPart(ctx)
+	require.NoError(t, err)
+
+	assert.Contains(t, part.Content, "USER-TIER-MARKER", "user-tier shared context must load")
+	assert.Contains(t, part.Content, "PROJECT-TIER-MARKER", "genie-home shared context must still load")
+	assert.Less(t,
+		strings.Index(part.Content, "USER-TIER-MARKER"),
+		strings.Index(part.Content, "PROJECT-TIER-MARKER"),
+		"user tier loads before the agent-wide tier (general before specific)")
+}
+
+// TestUserTierSharedContextDedupe: when HOME and genie home are the same
+// directory (hosted pods: both /var/agent), the file must load exactly once.
+func TestUserTierSharedContextDedupe(t *testing.T) {
+	home, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	t.Setenv("HOME", home)
+	writeAgentsMD(t, home, "DEDUPE-MARKER rules\n")
+
+	provider := NewProjectCtxManager(nil)
+	ctx := toolctx.WithGenieHome(context.Background(), home)
+	ctx = toolctx.WithWorkingDir(ctx, home)
+
+	part, err := provider.GetPart(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, strings.Count(part.Content, "DEDUPE-MARKER"),
+		"identical HOME and genie home must inject the shared file exactly once")
+}


### PR DESCRIPTION
Skills resolve through three tiers — internal, **user** (`$HOME/.genie/skills`), project (`<genie home>/.genie/skills`) — but shared context only had the genie-home tier. Hosted Mutiro agents exposed the asymmetry: the deployer points `HOME` at the agent state dir, so user-tier skills kept working while the genie-home tier — and with it the entire shared context — was broken for every conversation (mutirolabs/agents-armlog#14).

`$HOME/.genie/AGENTS.md` now loads for every session as the context twin of user-tier skills:

- Loads **first**, before the agent-wide `<genie home>/.genie/AGENTS.md` (general before specific), then the workspace's own context file.
- When `HOME` and genie home resolve to the same directory (hosted pods: both the state dir), the file loads **exactly once**.
- Covered by the Start-time warm from #20, so it inherits the cached/resilient/logged contract.

Tests: `TestUserTierSharedContext` (both tiers load, user first) and `TestUserTierSharedContextDedupe` (identical HOME/home → single injection). Red before, green after.

Companion to the infra fix (mutirolabs/mutiro#459 — hosted daemon now starts from the state dir): either alone cures the hosted outage; together the tiers are symmetric by design instead of by accident.