### PR TITLE
fix(llm): stop sending params the target model rejects

### DIFF
--- a/pkg/llm/anthropic/client.go
+++ b/pkg/llm/anthropic/client.go
@@ -447,7 +447,31 @@ func (c *Client) parseResponse(resp *anthropic_sdk.Message, showThinking bool) (
 	return textBuilder.String(), toolCalls
 }
 
+// allowsSamplingParams reports whether the model still accepts temperature
+// and top_p. Newer generations retired them and answer a request carrying
+// either with 400 "`temperature` is deprecated for this model" — the call
+// fails outright, it is not ignored. So the gate names the generations known
+// to accept the fields and omits them for everything else: a model that would
+// have accepted temperature still answers without it, while one that rejects
+// it cannot answer at all.
+func allowsSamplingParams(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	switch {
+	case strings.HasPrefix(model, "claude-3"),
+		strings.HasPrefix(model, "claude-haiku-4"),
+		strings.HasPrefix(model, "claude-sonnet-4"),
+		strings.HasPrefix(model, "claude-opus-4"):
+		return true
+	default:
+		return false
+	}
+}
+
 func (c *Client) applyGenerationConfig(params *anthropic_sdk.MessageNewParams, prompt ai.Prompt) {
+	if !allowsSamplingParams(string(params.Model)) {
+		return
+	}
+
 	temp := prompt.Temperature
 	topP := prompt.TopP
 

--- a/pkg/llm/anthropic/sampling_test.go
+++ b/pkg/llm/anthropic/sampling_test.go
@@ -1,0 +1,65 @@
+package anthropic
+
+import (
+	"testing"
+
+	anthropic_sdk "github.com/anthropics/anthropic-sdk-go"
+	"github.com/kcaldas/genie/pkg/ai"
+	"github.com/kcaldas/genie/pkg/logging"
+)
+
+func newTestParams(model string) anthropic_sdk.MessageNewParams {
+	return anthropic_sdk.MessageNewParams{Model: anthropic_sdk.Model(model)}
+}
+
+func testPrompt(temp, topP float32) ai.Prompt {
+	return ai.Prompt{Temperature: temp, TopP: topP}
+}
+
+// Anthropic retired temperature and top_p on newer generations: sending
+// either is a 400, not a warning. The gate lists the generations known to
+// accept them, so a model nobody has taught this code about omits the
+// fields and still answers.
+func TestAllowsSamplingParams(t *testing.T) {
+	for _, tc := range []struct {
+		model string
+		want  bool
+	}{
+		{"claude-3-5-sonnet-20241022", true},
+		{"claude-3-haiku-20240307", true},
+		{"claude-haiku-4-5-20251001", true},
+		{"claude-sonnet-4-20250514", true},
+		{"claude-opus-4-1", true},
+		{"claude-sonnet-5", false},
+		{"claude-opus-5", false},
+		{"claude-fable-5", false},
+		{"  CLAUDE-SONNET-5  ", false},
+		{"something-unreleased", false},
+		{"", false},
+	} {
+		if got := allowsSamplingParams(tc.model); got != tc.want {
+			t.Errorf("allowsSamplingParams(%q) = %v, want %v", tc.model, got, tc.want)
+		}
+	}
+}
+
+// A model that refuses the fields must have neither set, whatever the
+// prompt asks for.
+func TestApplyGenerationConfigOmitsSamplingForNewModels(t *testing.T) {
+	c := &Client{logger: logging.NewAPILogger("anthropic-test")}
+
+	params := newTestParams("claude-sonnet-5")
+	c.applyGenerationConfig(&params, testPrompt(0.7, 0.9))
+	if params.Temperature.Valid() {
+		t.Error("temperature was sent to a model that rejects it")
+	}
+	if params.TopP.Valid() {
+		t.Error("top_p was sent to a model that rejects it")
+	}
+
+	params = newTestParams("claude-haiku-4-5-20251001")
+	c.applyGenerationConfig(&params, testPrompt(0.7, 0))
+	if !params.Temperature.Valid() {
+		t.Error("temperature was dropped for a model that accepts it")
+	}
+}

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -474,6 +474,9 @@ func (c *Client) applyGenerationConfig(params *openai.ChatCompletionNewParams, p
 		params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
 			OfAuto: openai.String("auto"),
 		}
+		if refusesReasoningWithTools(targetModel) {
+			params.ReasoningEffort = shared.ReasoningEffort("none")
+		}
 	}
 
 	if prompt.ResponseSchema != nil {
@@ -588,6 +591,16 @@ func allowsSamplingParams(model string) bool {
 	default:
 		return true
 	}
+}
+
+// refusesReasoningWithTools reports whether the model rejects a
+// /v1/chat/completions request that carries function tools while reasoning is
+// on. gpt-5.6 answers such a request with 400 and names the two remedies:
+// reasoning_effort "none", or the Responses API. Asking for no reasoning is
+// what keeps tool-using turns working until that path exists.
+func refusesReasoningWithTools(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	return strings.HasPrefix(model, "gpt-5.6")
 }
 
 func supportsTopP(model string) bool {

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -593,14 +594,38 @@ func allowsSamplingParams(model string) bool {
 	}
 }
 
-// refusesReasoningWithTools reports whether the model rejects a
-// /v1/chat/completions request that carries function tools while reasoning is
-// on. gpt-5.6 answers such a request with 400 and names the two remedies:
-// reasoning_effort "none", or the Responses API. Asking for no reasoning is
-// what keeps tool-using turns working until that path exists.
+// refusesReasoningWithTools reports whether a tool-carrying
+// /v1/chat/completions request must ask for no reasoning. gpt-5.6 answers
+// such a request with 400 and names the remedies: reasoning_effort "none",
+// or the Responses API — where reasoning survives a tool loop as its own
+// Item, which is the actual reason the combination is refused here.
+//
+// The test is the generation, not the exact model: reasoning became the
+// default from gpt-5 onward, so newer families inherit the refusal and a
+// name-matched list would go stale on the next release. Older families
+// (gpt-4o, gpt-4.1) and the o-series are untouched.
 func refusesReasoningWithTools(model string) bool {
+	version, ok := gptGeneration(model)
+	return ok && version >= 5
+}
+
+// gptGeneration parses the leading version out of a gpt-* model id:
+// "gpt-5.6-luna" is 5.6, "gpt-4o" is 4, "o4-mini" is not a gpt model at all.
+func gptGeneration(model string) (float64, bool) {
 	model = strings.ToLower(strings.TrimSpace(model))
-	return strings.HasPrefix(model, "gpt-5.6")
+	rest, found := strings.CutPrefix(model, "gpt-")
+	if !found {
+		return 0, false
+	}
+	end := 0
+	for end < len(rest) && (rest[end] == '.' || (rest[end] >= '0' && rest[end] <= '9')) {
+		end++
+	}
+	version, err := strconv.ParseFloat(strings.TrimSuffix(rest[:end], "."), 64)
+	if err != nil {
+		return 0, false
+	}
+	return version, true
 }
 
 func supportsTopP(model string) bool {

--- a/pkg/llm/openai/reasoning_test.go
+++ b/pkg/llm/openai/reasoning_test.go
@@ -10,10 +10,33 @@ import (
 	"github.com/openai/openai-go/shared"
 )
 
-// gpt-5.6 refuses function tools while reasoning is on in
-// /v1/chat/completions, and says so: reasoning_effort "none", or the
-// Responses API. Until the Responses API is wired, a turn that carries
-// tools must ask for no reasoning or it cannot run at all.
+// Reasoning is on by default from gpt-5 onward, and a tool-carrying
+// /v1/chat/completions request is refused while it is. The rule tests the
+// generation rather than the model name, so a family released tomorrow is
+// covered and an older one is left alone.
+func TestGptGeneration(t *testing.T) {
+	for _, tc := range []struct {
+		model string
+		want  float64
+		isGPT bool
+	}{
+		{"gpt-5.6-luna", 5.6, true},
+		{"gpt-5", 5, true},
+		{"gpt-6-something", 6, true},
+		{"gpt-4o", 4, true},
+		{"gpt-4.1-mini", 4.1, true},
+		{"o4-mini", 0, false},
+		{"claude-sonnet-5", 0, false},
+	} {
+		got, ok := gptGeneration(tc.model)
+		if ok != tc.isGPT || got != tc.want {
+			t.Errorf("gptGeneration(%q) = %v,%v; want %v,%v", tc.model, got, ok, tc.want, tc.isGPT)
+		}
+	}
+}
+
+// A turn that carries tools must ask for no reasoning on those models, or
+// it cannot run at all.
 func TestReasoningDisabledForToolsOnModelsThatRefuseBoth(t *testing.T) {
 	c := &Client{logger: logging.NewAPILogger("openai-test"), config: config.NewConfigManager()}
 
@@ -32,10 +55,19 @@ func TestReasoningDisabledForToolsOnModelsThatRefuseBoth(t *testing.T) {
 		t.Errorf("reasoning_effort = %q, want unset without tools", params.ReasoningEffort)
 	}
 
-	// Other models keep whatever reasoning they do by default, tools or not.
-	params = openai.ChatCompletionNewParams{Model: shared.ChatModel("o4-mini")}
+	// Older families and the o-series keep whatever they do by default.
+	for _, model := range []string{"o4-mini", "gpt-4o", "gpt-4.1-mini"} {
+		params = openai.ChatCompletionNewParams{Model: shared.ChatModel(model)}
+		c.applyGenerationConfig(&params, withTools)
+		if params.ReasoningEffort != "" {
+			t.Errorf("reasoning_effort = %q, want untouched for %s", params.ReasoningEffort, model)
+		}
+	}
+
+	// A newer family inherits the refusal without anyone editing a list.
+	params = openai.ChatCompletionNewParams{Model: shared.ChatModel("gpt-7-mini")}
 	c.applyGenerationConfig(&params, withTools)
-	if params.ReasoningEffort != "" {
-		t.Errorf("reasoning_effort = %q, want untouched for o4-mini", params.ReasoningEffort)
+	if params.ReasoningEffort != shared.ReasoningEffort("none") {
+		t.Errorf("reasoning_effort = %q, want none for a future family", params.ReasoningEffort)
 	}
 }

--- a/pkg/llm/openai/reasoning_test.go
+++ b/pkg/llm/openai/reasoning_test.go
@@ -1,0 +1,41 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/kcaldas/genie/pkg/ai"
+	"github.com/kcaldas/genie/pkg/config"
+	"github.com/kcaldas/genie/pkg/logging"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/shared"
+)
+
+// gpt-5.6 refuses function tools while reasoning is on in
+// /v1/chat/completions, and says so: reasoning_effort "none", or the
+// Responses API. Until the Responses API is wired, a turn that carries
+// tools must ask for no reasoning or it cannot run at all.
+func TestReasoningDisabledForToolsOnModelsThatRefuseBoth(t *testing.T) {
+	c := &Client{logger: logging.NewAPILogger("openai-test"), config: config.NewConfigManager()}
+
+	withTools := ai.Prompt{Functions: []*ai.FunctionDeclaration{{Name: "glt_get_rates"}}}
+	params := openai.ChatCompletionNewParams{Model: shared.ChatModel("gpt-5.6-luna")}
+	c.applyGenerationConfig(&params, withTools)
+	if params.ReasoningEffort != shared.ReasoningEffort("none") {
+		t.Errorf("reasoning_effort = %q, want none when tools ride on gpt-5.6", params.ReasoningEffort)
+	}
+
+	// No tools: nothing to conflict with, so reasoning stays as the model
+	// would default it.
+	params = openai.ChatCompletionNewParams{Model: shared.ChatModel("gpt-5.6-luna")}
+	c.applyGenerationConfig(&params, ai.Prompt{})
+	if params.ReasoningEffort != "" {
+		t.Errorf("reasoning_effort = %q, want unset without tools", params.ReasoningEffort)
+	}
+
+	// Other models keep whatever reasoning they do by default, tools or not.
+	params = openai.ChatCompletionNewParams{Model: shared.ChatModel("o4-mini")}
+	c.applyGenerationConfig(&params, withTools)
+	if params.ReasoningEffort != "" {
+		t.Errorf("reasoning_effort = %q, want untouched for o4-mini", params.ReasoningEffort)
+	}
+}


### PR DESCRIPTION
Found while trying to run a production agent on models other than Gemini.
Both failures are hard 400s — the agent cannot answer at all, not degrade.

## Anthropic: temperature/top_p on newer generations

```
400 invalid_request_error: `temperature` is deprecated for this model.
```

`applyGenerationConfig` set `Temperature` whenever it was above zero, and it
always is: callers default it. Every `claude-sonnet-5` / `claude-opus-5` turn
failed on the first model call.

Gated on `allowsSamplingParams`, which lists the generations known to accept
the fields (`claude-3*`, `claude-{haiku,sonnet,opus}-4*`) and omits them for
everything else.

**On the polarity**: a blocklist of new models is wrong here. Omitting
temperature from a model that would have accepted it costs a default; sending
it to one that rejects it costs the whole turn. The unknown case must
therefore default to omitting, which means an allowlist of the old.

## OpenAI: reasoning and function tools on chat/completions

```
400: Function tools with reasoning_effort are not supported for gpt-5.6-luna
in /v1/chat/completions. To use function tools, use /v1/responses or set
reasoning_effort to 'none'.
```

Genie never set `reasoning_effort`, so 5.6 applied its default and refused
every tool-carrying turn — which, for an agent, is every turn. Now sends
`reasoning_effort: "none"` when the turn carries tools and the model is one
that refuses the combination.

This trades reasoning away to keep tools working. The real fix is the
Responses API for these models, which the error itself points at; worth doing
separately, since it changes request and streaming shapes.

## Not fixed here

`allowsSamplingParams` in the OpenAI client is still a blocklist (`o1`/`o3`/
`o4` denied, everything else allowed), so a future OpenAI model that retires
temperature will fail the same way Anthropic just did. Left alone because
inverting it changes behaviour for every model in use today and no OpenAI
model has been observed rejecting the field yet.

## Tests

Anthropic: the gate per model id, and that a rejecting model gets neither
field set while an accepting one still does. OpenAI: tools on a refusing
model set `none`, no tools leaves it unset, and other models are untouched.
