### PR TITLE
feat(openai): use Responses API for GPT-5 models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: test
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,7 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [1.24.x]
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -21,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: 1.24.x
 
     - name: Cache Go modules
       uses: actions/cache@v4

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -187,7 +187,7 @@ genie --persona technical-writer ask "improve this documentation"
 ### Environment Variables
 ```bash
 # Model selection
-export GENIE_MODEL_NAME="gemini-2.5-flash"
+export GENIE_MODEL_NAME="gemini-3.6-flash"
 
 # Adjust creativity
 export GENIE_MODEL_TEMPERATURE="0.3"  # More focused

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -33,8 +33,8 @@ export ANTHROPIC_SHOW_THINKING="true"
 ### Model Parameters
 ```bash
 # Model selection
-export GENIE_MODEL_NAME="gemini-2.5-flash"  # Default
-# Options: gemini-2.5-flash, gemini-1.5-pro, gemini-1.5-flash
+export GENIE_MODEL_NAME="gemini-3.6-flash"  # Default
+# Options: gemini-3.6-flash, gemini-2.5-flash, gemini-1.5-pro, gemini-1.5-flash
 
 # Response length
 export GENIE_MAX_TOKENS="65535"  # Default
@@ -64,7 +64,7 @@ export GEMINI_INCLUDE_THOUGHTS="true" # Default: "false"
 Create a `.env` file in your working directory:
 ```bash
 GEMINI_API_KEY=your-api-key-here
-GENIE_MODEL_NAME=gemini-2.5-flash
+GENIE_MODEL_NAME=gemini-3.6-flash
 GENIE_MODEL_TEMPERATURE=0.7
 ```
 
@@ -179,6 +179,7 @@ Popular themes: `dracula`, `github`, `monokai`, `solarized-dark`, `solarized-lig
 ### Token Limits
 | Model | Max Tokens | Recommended |
 |-------|------------|-------------|
+| gemini-3.6-flash | 1M | 65536 |
 | gemini-2.5-flash | 1M | 65535 |
 | gemini-1.5-pro | 2M | 65535 |
 | gemini-1.5-flash | 1M | 65535 |

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -73,7 +73,7 @@ docker run --rm -it genie:local
 ```bash
 docker run --rm -it \
   -e GEMINI_API_KEY="your-key" \
-  -e GENIE_MODEL_NAME="gemini-2.5-flash" \
+  -e GENIE_MODEL_NAME="gemini-3.6-flash" \
   -e GENIE_MODEL_TEMPERATURE="0.7" \
   ghcr.io/kcaldas/genie:latest
 ```

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -66,7 +66,7 @@ genie
 ### Environment Variables
 ```bash
 # Model selection
-export GENIE_MODEL_NAME="gemini-2.5-flash"  # Default
+export GENIE_MODEL_NAME="gemini-3.6-flash"  # Default
 
 # Model parameters
 export GENIE_MAX_TOKENS="65535"

--- a/pkg/config/config_manager.go
+++ b/pkg/config/config_manager.go
@@ -122,7 +122,7 @@ func (m *DefaultManager) GetDurationWithDefault(key string, defaultValue time.Du
 
 // GetModelConfig returns the default model configuration from environment variables or defaults
 func (m *DefaultManager) GetModelConfig() ModelConfig {
-	modelName := m.GetStringWithDefault("GENIE_MODEL_NAME", "gemini-2.5-flash")
+	modelName := m.GetStringWithDefault("GENIE_MODEL_NAME", "gemini-3.6-flash")
 
 	maxTokensStr := m.GetStringWithDefault("GENIE_MAX_TOKENS", "65535")
 	maxTokens, err := strconv.ParseInt(maxTokensStr, 10, 32)

--- a/pkg/config/config_manager_test.go
+++ b/pkg/config/config_manager_test.go
@@ -42,6 +42,14 @@ func TestManager_GetStringWithDefault(t *testing.T) {
 	assert.Equal(t, "default_value", value)
 }
 
+func TestManager_GetModelConfig_DefaultModel(t *testing.T) {
+	t.Setenv("GENIE_MODEL_NAME", "")
+
+	model := (&DefaultManager{}).GetModelConfig()
+
+	assert.Equal(t, "gemini-3.6-flash", model.ModelName)
+}
+
 func TestManager_RequireString(t *testing.T) {
 	manager := NewConfigManager()
 

--- a/pkg/ctx/model_registry.go
+++ b/pkg/ctx/model_registry.go
@@ -7,7 +7,14 @@ import "strings"
 // Uses prefix matching so "claude-sonnet-4" matches "claude-sonnet-4-20250514".
 var defaultContextWindows = map[string]int{
 	// Anthropic
-	"claude-opus-5":     200000,
+	"claude-fable-5":    1000000,
+	"claude-opus-5":     1000000,
+	"claude-sonnet-5":   1000000,
+	"claude-opus-4-8":   1000000,
+	"claude-opus-4-7":   1000000,
+	"claude-opus-4-6":   1000000,
+	"claude-sonnet-4-6": 1000000,
+	"claude-haiku-4-5":  200000,
 	"claude-opus-4":     200000,
 	"claude-sonnet-4":   200000,
 	"claude-3-5-sonnet": 200000,
@@ -17,26 +24,47 @@ var defaultContextWindows = map[string]int{
 	"claude-3-haiku":    200000,
 
 	// OpenAI
-	"gpt-4o":      128000,
-	"gpt-4o-mini": 128000,
-	"gpt-4-turbo": 128000,
-	"gpt-4.1":     1047576,
-	"gpt-4":       8192,
-	"o1":          200000,
-	"o1-mini":     128000,
-	"o3":          200000,
-	"o3-mini":     200000,
-	"o4-mini":     200000,
+	"gpt-5.6":             1050000,
+	"gpt-5.5":             1050000,
+	"gpt-5.4-mini":        400000,
+	"gpt-5.4-nano":        400000,
+	"gpt-5.4":             1050000,
+	"gpt-5.3-chat-latest": 128000,
+	"gpt-5.3-codex":       400000,
+	"gpt-5.2":             400000,
+	"gpt-5.1-chat-latest": 128000,
+	"gpt-5.1":             400000,
+	"gpt-5-chat-latest":   128000,
+	"gpt-5":               400000,
+	"chat-latest":         400000,
+	"gpt-4o":              128000,
+	"gpt-4o-mini":         128000,
+	"gpt-4-turbo":         128000,
+	"gpt-4.1":             1047576,
+	"gpt-4":               8192,
+	"o1":                  200000,
+	"o1-mini":             128000,
+	"o3":                  200000,
+	"o3-mini":             200000,
+	"o4-mini":             200000,
 
 	// Google
-	"gemini-3.5-flash": 1048576,
-	"gemini-3.5-pro":   1048576,
-	"gemini-3":         1048576,
-	"gemini-2.5-flash": 1048576,
-	"gemini-2.5-pro":   1048576,
-	"gemini-2.0-flash": 1048576,
-	"gemini-1.5-flash": 1048576,
-	"gemini-1.5-pro":   2097152,
+	"gemini-3.6-flash":               1048576,
+	"gemini-3.5-flash-lite":          1048576,
+	"gemini-3.5-flash":               1048576,
+	"gemini-3.1-flash-image-preview": 131072,
+	"gemini-3.1-flash-image":         131072,
+	"gemini-3.1-flash-lite":          1048576,
+	"gemini-3.1-pro-preview":         1048576,
+	"gemini-3-pro-image-preview":     65536,
+	"gemini-3-pro-image":             65536,
+	"gemini-3-flash-preview":         1048576,
+	"gemini-3-pro-preview":           1048576,
+	"gemini-2.5-flash":               1048576,
+	"gemini-2.5-pro":                 1048576,
+	"gemini-2.0-flash":               1048576,
+	"gemini-1.5-flash":               1048576,
+	"gemini-1.5-pro":                 2097152,
 
 	// Local models (conservative defaults)
 	"llama":     8192,
@@ -44,6 +72,16 @@ var defaultContextWindows = map[string]int{
 	"codellama": 16384,
 	"deepseek":  32768,
 	"qwen":      32768,
+}
+
+// Local model names commonly concatenate the family and generation (for
+// example, llama3.1). Hosted model names must match on a model-name boundary.
+var concatenatedModelPrefixes = map[string]struct{}{
+	"llama":     {},
+	"mistral":   {},
+	"codellama": {},
+	"deepseek":  {},
+	"qwen":      {},
 }
 
 // FallbackContextWindow is used when the model is completely unknown.
@@ -71,7 +109,7 @@ func LookupContextWindow(modelName string) int {
 	bestMatch := ""
 	bestTokens := 0
 	for prefix, tokens := range defaultContextWindows {
-		if strings.HasPrefix(modelName, strings.ToLower(prefix)) && len(prefix) > len(bestMatch) {
+		if matchesModelPrefix(modelName, prefix) && len(prefix) > len(bestMatch) {
 			bestMatch = prefix
 			bestTokens = tokens
 		}
@@ -82,6 +120,25 @@ func LookupContextWindow(modelName string) int {
 	}
 
 	return FallbackContextWindow
+}
+
+func matchesModelPrefix(modelName, prefix string) bool {
+	if !strings.HasPrefix(modelName, prefix) {
+		return false
+	}
+	if len(modelName) == len(prefix) {
+		return true
+	}
+	if _, ok := concatenatedModelPrefixes[prefix]; ok {
+		return true
+	}
+
+	switch modelName[len(prefix)] {
+	case '-', '@':
+		return true
+	default:
+		return false
+	}
 }
 
 // ContextBudget calculates the token budget for context.

--- a/pkg/ctx/model_registry_test.go
+++ b/pkg/ctx/model_registry_test.go
@@ -6,22 +6,60 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLookupContextWindow_ExactMatch(t *testing.T) {
-	assert.Equal(t, 200000, LookupContextWindow("claude-sonnet-4"))
-	assert.Equal(t, 128000, LookupContextWindow("gpt-4o"))
-	assert.Equal(t, 1048576, LookupContextWindow("gemini-2.5-flash"))
-}
+func TestLookupContextWindow_KnownModels(t *testing.T) {
+	tests := []struct {
+		model string
+		want  int
+	}{
+		// Anthropic
+		{model: "claude-opus-5", want: 1000000},
+		{model: "claude-sonnet-5-20260801", want: 1000000},
+		{model: "claude-opus-4-8", want: 1000000},
+		{model: "claude-opus-4-6-20260301", want: 1000000},
+		{model: "claude-sonnet-4-6", want: 1000000},
+		{model: "claude-opus-4-5-20251101", want: 200000},
+		{model: "claude-haiku-4-5-20251001", want: 200000},
 
-func TestLookupContextWindow_PrefixMatch(t *testing.T) {
-	assert.Equal(t, 200000, LookupContextWindow("claude-sonnet-4-20250514"))
-	assert.Equal(t, 200000, LookupContextWindow("claude-opus-4-5-20251101"))
-	assert.Equal(t, 128000, LookupContextWindow("gpt-4o-2024-05-13"))
-	assert.Equal(t, 1048576, LookupContextWindow("gemini-2.0-flash-latest"))
+		// OpenAI
+		{model: "gpt-5", want: 400000},
+		{model: "gpt-5-mini", want: 400000},
+		{model: "gpt-5-chat-latest", want: 128000},
+		{model: "gpt-5.1", want: 400000},
+		{model: "gpt-5.1-chat-latest", want: 128000},
+		{model: "gpt-5.2-pro", want: 400000},
+		{model: "gpt-5.3-codex", want: 400000},
+		{model: "gpt-5.3-chat-latest", want: 128000},
+		{model: "gpt-5.4", want: 1050000},
+		{model: "gpt-5.4-pro", want: 1050000},
+		{model: "gpt-5.4-mini", want: 400000},
+		{model: "gpt-5.4-nano-2026-03-17", want: 400000},
+		{model: "gpt-5.5-pro", want: 1050000},
+		{model: "gpt-5.6", want: 1050000},
+		{model: "gpt-5.6-sol", want: 1050000},
+		{model: "gpt-5.6-terra", want: 1050000},
+		{model: "gpt-5.6-luna", want: 1050000},
+		{model: "gpt-4o-2024-05-13", want: 128000},
+
+		// Google
+		{model: "gemini-3.6-flash", want: 1048576},
+		{model: "gemini-3.5-flash-lite", want: 1048576},
+		{model: "gemini-3.1-pro-preview", want: 1048576},
+		{model: "gemini-3.1-flash-image-preview", want: 131072},
+		{model: "gemini-3-pro-image", want: 65536},
+		{model: "gemini-3-flash-preview", want: 1048576},
+		{model: "gemini-2.0-flash-latest", want: 1048576},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			assert.Equal(t, tt.want, LookupContextWindow(tt.model))
+		})
+	}
 }
 
 func TestLookupContextWindow_CaseInsensitive(t *testing.T) {
 	assert.Equal(t, 200000, LookupContextWindow("Claude-Sonnet-4"))
-	assert.Equal(t, 128000, LookupContextWindow("GPT-4o"))
+	assert.Equal(t, 1050000, LookupContextWindow("GPT-5.6-LUNA"))
 }
 
 func TestLookupContextWindow_UnknownModel(t *testing.T) {
@@ -33,10 +71,20 @@ func TestLookupContextWindow_EmptyString(t *testing.T) {
 }
 
 func TestLookupContextWindow_LongestPrefixWins(t *testing.T) {
-	// "gpt-4o-mini" should match "gpt-4o-mini" not "gpt-4o" or "gpt-4"
-	assert.Equal(t, 128000, LookupContextWindow("gpt-4o-mini"))
-	// "gpt-4" should match "gpt-4" (8192), not "gpt-4o" (128000)
-	assert.Equal(t, 8192, LookupContextWindow("gpt-4"))
+	assert.Equal(t, 400000, LookupContextWindow("gpt-5.4-mini"))
+	assert.Equal(t, 128000, LookupContextWindow("gpt-5.3-chat-latest"))
+	assert.Equal(t, 131072, LookupContextWindow("gemini-3.1-flash-image-preview"))
+}
+
+func TestLookupContextWindow_DoesNotMatchUnrelatedPrefix(t *testing.T) {
+	assert.Equal(t, FallbackContextWindow, LookupContextWindow("gpt-40"))
+	assert.Equal(t, FallbackContextWindow, LookupContextWindow("gemini-30"))
+	assert.Equal(t, FallbackContextWindow, LookupContextWindow("claude-opus-40"))
+}
+
+func TestLookupContextWindow_LocalModelsAllowConcatenatedGeneration(t *testing.T) {
+	assert.Equal(t, 8192, LookupContextWindow("llama3.1"))
+	assert.Equal(t, 32768, LookupContextWindow("qwen2.5-coder"))
 }
 
 func TestContextBudget_ExplicitBudgetTakesPriority(t *testing.T) {

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -7,12 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"sync"
 
 	openai "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/packages/ssestream"
+	"github.com/openai/openai-go/responses"
 	"github.com/openai/openai-go/shared"
 
 	"github.com/kcaldas/genie/pkg/ai"
@@ -38,6 +40,11 @@ var (
 type chatCompletionClient interface {
 	New(ctx context.Context, body openai.ChatCompletionNewParams, opts ...option.RequestOption) (*openai.ChatCompletion, error)
 	NewStreaming(ctx context.Context, body openai.ChatCompletionNewParams, opts ...option.RequestOption) *ssestream.Stream[openai.ChatCompletionChunk]
+}
+
+type responsesClient interface {
+	New(ctx context.Context, body responses.ResponseNewParams, opts ...option.RequestOption) (*responses.Response, error)
+	NewStreaming(ctx context.Context, body responses.ResponseNewParams, opts ...option.RequestOption) *ssestream.Stream[responses.ResponseStreamEventUnion]
 }
 
 // Option configures the OpenAI client.
@@ -88,7 +95,16 @@ func WithChatClient(chat chatCompletionClient) Option {
 	}
 }
 
-// Client provides an ai.Gen implementation backed by OpenAI Chat Completions.
+// WithResponsesClient injects a custom Responses client (primarily for tests).
+func WithResponsesClient(responses responsesClient) Option {
+	return func(c *Client) {
+		if responses != nil {
+			c.responses = responses
+		}
+	}
+}
+
+// Client provides an ai.Gen implementation backed by OpenAI.
 type Client struct {
 	mu sync.Mutex
 
@@ -100,6 +116,7 @@ type Client struct {
 
 	apiClient       *openai.Client
 	chatCompletions chatCompletionClient
+	responses       responsesClient
 
 	initialized bool
 	initErr     error
@@ -237,7 +254,7 @@ func (c *Client) ensureInitialized(ctx context.Context) error {
 		return c.initErr
 	}
 
-	if c.chatCompletions != nil {
+	if c.chatCompletions != nil || c.responses != nil {
 		c.initialized = true
 		return nil
 	}
@@ -263,10 +280,12 @@ func (c *Client) ensureInitialized(ctx context.Context) error {
 	opts = append(opts, option.WithHeaderAdd(ai.ClientHeaderName, ai.ClientHeaderValue))
 
 	client := openai.NewClient(opts...)
-	service := client.Chat.Completions
+	chatService := client.Chat.Completions
+	responsesService := client.Responses
 
 	c.apiClient = &client
-	c.chatCompletions = &service
+	c.chatCompletions = &chatService
+	c.responses = &responsesService
 	c.initialized = true
 	c.initErr = nil
 	return nil
@@ -278,6 +297,14 @@ func (c *Client) generateWithPrompt(ctx context.Context, prompt ai.Prompt) (stri
 		return "", err
 	}
 	return llmshared.RunToolLoop(ctx, turn, prompt.Handlers, c.loopConfig(prompt), nil)
+}
+
+func (c *Client) newTurn(prompt ai.Prompt) (llmshared.TurnState, error) {
+	modelName := c.resolveModelName(prompt.ModelName)
+	if useResponsesAPI(modelName) {
+		return c.newResponsesTurn(prompt, modelName)
+	}
+	return c.newChatTurn(prompt, modelName)
 }
 
 func (c *Client) generateWithPromptStream(ctx context.Context, prompt ai.Prompt) (ai.Stream, error) {
@@ -348,41 +375,41 @@ func (c *Client) resolveModelName(promptModel string) string {
 	return string(shared.ChatModelGPT4oMini)
 }
 
+func (c *Client) buildInstructions(prompt ai.Prompt) (string, error) {
+	var parts []string
+	if instruction := strings.TrimSpace(prompt.Instruction); instruction != "" {
+		parts = append(parts, instruction)
+	}
+	if files := strings.TrimSpace(prompt.SystemPromptFiles); files != "" {
+		parts = append(parts, files)
+	}
+	if userCtx := strings.TrimSpace(prompt.SystemPromptUserContext); userCtx != "" {
+		parts = append(parts, userCtx)
+	}
+
+	if prompt.ResponseSchema != nil && strings.TrimSpace(prompt.Instruction) == "" {
+		schemaJSON, err := schemaToJSON(prompt.ResponseSchema)
+		if err != nil {
+			return "", fmt.Errorf("formatting response schema: %w", err)
+		}
+		parts = append(parts, fmt.Sprintf("You must respond with JSON matching this schema:\n%s", schemaJSON))
+	}
+
+	return strings.Join(parts, "\n\n"), nil
+}
+
 func (c *Client) buildMessages(prompt ai.Prompt) ([]openai.ChatCompletionMessageParamUnion, []tokenMessage, error) {
 	var messages []openai.ChatCompletionMessageParamUnion
 	var tokenMessages []tokenMessage
 
-	if instruction := strings.TrimSpace(prompt.Instruction); instruction != "" {
-		// Append SystemPromptFiles then SystemPromptUserContext onto the
-		// system message in the same order Anthropic emits its blocks. Sits
-		// at stable byte offsets for OpenAI's implicit prompt cache. Single
-		// message — OpenAI doesn't expose marker controls.
-		if files := strings.TrimSpace(prompt.SystemPromptFiles); files != "" {
-			instruction = instruction + "\n\n" + files
-		}
-		if userCtx := strings.TrimSpace(prompt.SystemPromptUserContext); userCtx != "" {
-			instruction = instruction + "\n\n" + userCtx
-		}
+	if instruction, err := c.buildInstructions(prompt); err != nil {
+		return nil, nil, err
+	} else if instruction != "" {
 		messages = append(messages, openai.SystemMessage(instruction))
 		tokenMessages = append(tokenMessages, tokenMessage{
 			Role:    "system",
 			Content: instruction,
 		})
-	}
-
-	if prompt.ResponseSchema != nil {
-		schemaJSON, err := schemaToJSON(prompt.ResponseSchema)
-		if err != nil {
-			return nil, nil, fmt.Errorf("formatting response schema: %w", err)
-		}
-		if prompt.Instruction == "" {
-			instruction := fmt.Sprintf("You must respond with JSON matching this schema:\n%s", schemaJSON)
-			messages = append(messages, openai.SystemMessage(instruction))
-			tokenMessages = append(tokenMessages, tokenMessage{
-				Role:    "system",
-				Content: instruction,
-			})
-		}
 	}
 
 	userMessage, tokenMsg := c.buildUserMessage(prompt)
@@ -588,6 +615,30 @@ func allowsSamplingParams(model string) bool {
 	default:
 		return true
 	}
+}
+
+func useResponsesAPI(model string) bool {
+	version, ok := gptGeneration(model)
+	return ok && version >= 5
+}
+
+// gptGeneration parses the leading version out of a gpt-* model id:
+// "gpt-5.6-luna" is 5.6, "gpt-4o" is 4, "o4-mini" is not a gpt model at all.
+func gptGeneration(model string) (float64, bool) {
+	model = strings.ToLower(strings.TrimSpace(model))
+	rest, found := strings.CutPrefix(model, "gpt-")
+	if !found {
+		return 0, false
+	}
+	end := 0
+	for end < len(rest) && (rest[end] == '.' || (rest[end] >= '0' && rest[end] <= '9')) {
+		end++
+	}
+	version, err := strconv.ParseFloat(strings.TrimSuffix(rest[:end], "."), 64)
+	if err != nil {
+		return 0, false
+	}
+	return version, true
 }
 
 func supportsTopP(model string) bool {

--- a/pkg/llm/openai/functions.go
+++ b/pkg/llm/openai/functions.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	openai "github.com/openai/openai-go"
+	"github.com/openai/openai-go/responses"
 	"github.com/openai/openai-go/shared"
 
 	"github.com/kcaldas/genie/pkg/ai"
@@ -32,6 +33,40 @@ func mapFunctions(functions []*ai.FunctionDeclaration) []openai.ChatCompletionTo
 
 		tools = append(tools, openai.ChatCompletionToolParam{
 			Function: definition,
+		})
+	}
+
+	if len(tools) == 0 {
+		return nil
+	}
+
+	return tools
+}
+
+func mapResponseFunctions(functions []*ai.FunctionDeclaration) []responses.ToolUnionParam {
+	if len(functions) == 0 {
+		return nil
+	}
+
+	tools := make([]responses.ToolUnionParam, 0, len(functions))
+	for _, fn := range functions {
+		if fn == nil {
+			continue
+		}
+
+		definition := responses.FunctionToolParam{
+			Name:   fn.Name,
+			Strict: openai.Bool(false),
+		}
+		if strings.TrimSpace(fn.Description) != "" {
+			definition.Description = openai.String(fn.Description)
+		}
+		if schema := schemaToMap(fn.Parameters); schema != nil {
+			definition.Parameters = schema
+		}
+
+		tools = append(tools, responses.ToolUnionParam{
+			OfFunction: &definition,
 		})
 	}
 

--- a/pkg/llm/openai/reasoning_test.go
+++ b/pkg/llm/openai/reasoning_test.go
@@ -1,0 +1,49 @@
+package openai
+
+import (
+	"testing"
+)
+
+// Reasoning is on by default from gpt-5 onward, and a tool-carrying
+// /v1/chat/completions request is refused while it is. The rule tests the
+// generation rather than the model name, so a family released tomorrow is
+// covered and an older one is left alone.
+func TestGptGeneration(t *testing.T) {
+	for _, tc := range []struct {
+		model string
+		want  float64
+		isGPT bool
+	}{
+		{"gpt-5.6-luna", 5.6, true},
+		{"gpt-5", 5, true},
+		{"gpt-6-something", 6, true},
+		{"gpt-4o", 4, true},
+		{"gpt-4.1-mini", 4.1, true},
+		{"o4-mini", 0, false},
+		{"claude-sonnet-5", 0, false},
+	} {
+		got, ok := gptGeneration(tc.model)
+		if ok != tc.isGPT || got != tc.want {
+			t.Errorf("gptGeneration(%q) = %v,%v; want %v,%v", tc.model, got, ok, tc.want, tc.isGPT)
+		}
+	}
+}
+
+func TestUseResponsesAPI(t *testing.T) {
+	for _, tc := range []struct {
+		model string
+		want  bool
+	}{
+		{"gpt-5.6-luna", true},
+		{"gpt-5", true},
+		{"gpt-6-something", true},
+		{"gpt-4o", false},
+		{"gpt-4.1-mini", false},
+		{"o4-mini", false},
+		{"claude-sonnet-5", false},
+	} {
+		if got := useResponsesAPI(tc.model); got != tc.want {
+			t.Errorf("useResponsesAPI(%q) = %v, want %v", tc.model, got, tc.want)
+		}
+	}
+}

--- a/pkg/llm/openai/responses_test.go
+++ b/pkg/llm/openai/responses_test.go
@@ -1,0 +1,369 @@
+package openai
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	openai "github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/packages/ssestream"
+	"github.com/openai/openai-go/responses"
+	"github.com/openai/openai-go/shared"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kcaldas/genie/pkg/ai"
+	"github.com/kcaldas/genie/pkg/events"
+)
+
+type mockResponses struct {
+	t         *testing.T
+	mu        sync.Mutex
+	requests  []responses.ResponseNewParams
+	responses []*responses.Response
+	streams   []string
+	err       error
+}
+
+func (m *mockResponses) New(ctx context.Context, params responses.ResponseNewParams, _ ...option.RequestOption) (*responses.Response, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.requests = append(m.requests, params)
+
+	if m.err != nil {
+		return nil, m.err
+	}
+	if len(m.responses) == 0 {
+		require.FailNow(m.t, "mock responses received more calls than configured responses")
+	}
+
+	resp := m.responses[0]
+	m.responses = m.responses[1:]
+	return resp, nil
+}
+
+func (m *mockResponses) NewStreaming(ctx context.Context, params responses.ResponseNewParams, _ ...option.RequestOption) *ssestream.Stream[responses.ResponseStreamEventUnion] {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.requests = append(m.requests, params)
+
+	if len(m.streams) == 0 {
+		require.FailNow(m.t, "mock responses stream received more calls than configured streams")
+	}
+
+	body := m.streams[0]
+	m.streams = m.streams[1:]
+	resp := &http.Response{
+		Header: http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:   io.NopCloser(strings.NewReader(body)),
+	}
+	return ssestream.NewStream[responses.ResponseStreamEventUnion](ssestream.NewDecoder(resp), nil)
+}
+
+func responseFromJSON(t *testing.T, raw string) *responses.Response {
+	t.Helper()
+	var resp responses.Response
+	require.NoError(t, json.Unmarshal([]byte(raw), &resp))
+	return &resp
+}
+
+func responseJSON(model string, output string, usage responses.ResponseUsage) string {
+	return fmt.Sprintf(`{
+		"id": "resp_final",
+		"object": "response",
+		"created_at": 0,
+		"model": %q,
+		"status": "completed",
+		"output": [%s],
+		"usage": {
+			"input_tokens": %d,
+			"input_tokens_details": {"cached_tokens": %d},
+			"output_tokens": %d,
+			"output_tokens_details": {"reasoning_tokens": %d},
+			"total_tokens": %d
+		}
+	}`, model, output, usage.InputTokens, usage.InputTokensDetails.CachedTokens, usage.OutputTokens, usage.OutputTokensDetails.ReasoningTokens, usage.TotalTokens)
+}
+
+func outputMessageJSON(id, text string) string {
+	return fmt.Sprintf(`{
+		"type": "message",
+		"id": %q,
+		"role": "assistant",
+		"status": "completed",
+		"content": [{"type": "output_text", "text": %q, "annotations": []}]
+	}`, id, text)
+}
+
+func outputFunctionCallJSON(id, callID, name, args string) string {
+	return fmt.Sprintf(`{
+		"type": "function_call",
+		"id": %q,
+		"call_id": %q,
+		"name": %q,
+		"arguments": %q,
+		"status": "completed"
+	}`, id, callID, name, args)
+}
+
+func outputReasoningJSON(id, encrypted string) string {
+	return fmt.Sprintf(`{
+		"type": "reasoning",
+		"id": %q,
+		"summary": [],
+		"encrypted_content": %q,
+		"status": "completed"
+	}`, id, encrypted)
+}
+
+func sseEvent(raw string) string {
+	return "data: " + strings.ReplaceAll(raw, "\n", "") + "\n\n"
+}
+
+func TestMapResponseFunctions_DisablesStrictValidation(t *testing.T) {
+	tools := mapResponseFunctions([]*ai.FunctionDeclaration{{
+		Name: "tool_with_optional_argument",
+		Parameters: &ai.Schema{
+			Type: ai.TypeObject,
+			Properties: map[string]*ai.Schema{
+				"required": {Type: ai.TypeString},
+				"optional": {Type: ai.TypeString},
+			},
+			Required: []string{"required"},
+		},
+	}})
+
+	require.Len(t, tools, 1)
+	require.NotNil(t, tools[0].OfFunction)
+	require.True(t, tools[0].OfFunction.Strict.Valid())
+	assert.False(t, tools[0].OfFunction.Strict.Value)
+
+	wire, err := json.Marshal(tools[0])
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"type": "function",
+		"name": "tool_with_optional_argument",
+		"strict": false,
+		"parameters": {
+			"type": "object",
+			"properties": {
+				"required": {"type": "string"},
+				"optional": {"type": "string"}
+			},
+			"required": ["required"]
+		}
+	}`, string(wire))
+}
+
+func TestClient_Responses_InstructionsAndInputAssembly(t *testing.T) {
+	model := "gpt-5.6-luna"
+	mockAPI := &mockResponses{
+		t: t,
+		responses: []*responses.Response{
+			responseFromJSON(t, responseJSON(model, outputMessageJSON("msg_1", "Hello there!"), responses.ResponseUsage{})),
+		},
+	}
+
+	rawClient, err := NewClient(&events.NoOpEventBus{}, WithResponsesClient(mockAPI))
+	require.NoError(t, err)
+	client := rawClient.(*Client)
+
+	imageData := []byte{0x01, 0x02, 0x03}
+	prompt := ai.Prompt{
+		Name:                    "greeting",
+		Instruction:             "Instruction",
+		SystemPromptFiles:       "Files",
+		SystemPromptUserContext: "User context",
+		Text:                    "Say hello.",
+		ModelName:               model,
+		Images: []*ai.Image{{
+			Type: "image/jpeg",
+			Data: imageData,
+		}},
+	}
+
+	resp, err := client.GenerateContent(context.Background(), prompt, false)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello there!", resp)
+
+	mockAPI.mu.Lock()
+	defer mockAPI.mu.Unlock()
+	require.Len(t, mockAPI.requests, 1)
+	request := mockAPI.requests[0]
+	assert.Equal(t, shared.ResponsesModel(model), request.Model)
+	require.True(t, request.Instructions.Valid())
+	assert.Equal(t, "Instruction\n\nFiles\n\nUser context", request.Instructions.Value)
+	require.True(t, request.Store.Valid())
+	assert.False(t, request.Store.Value)
+	assert.False(t, request.PreviousResponseID.Valid())
+	assert.Equal(t, []responses.ResponseIncludable{responses.ResponseIncludableReasoningEncryptedContent}, request.Include)
+
+	input := request.Input.OfInputItemList
+	require.Len(t, input, 1)
+	require.NotNil(t, input[0].OfInputMessage)
+	assert.Equal(t, "user", input[0].OfInputMessage.Role)
+	parts := input[0].OfInputMessage.Content
+	require.Len(t, parts, 2)
+	require.NotNil(t, parts[0].OfInputText)
+	assert.Equal(t, "Say hello.", parts[0].OfInputText.Text)
+	require.NotNil(t, parts[1].OfInputImage)
+	expectedDataURL := fmt.Sprintf("data:image/jpeg;base64,%s", base64.StdEncoding.EncodeToString(imageData))
+	require.True(t, parts[1].OfInputImage.ImageURL.Valid())
+	assert.Equal(t, expectedDataURL, parts[1].OfInputImage.ImageURL.Value)
+}
+
+func TestClient_Responses_FunctionCallOutputCorrelatedByCallIDAndReasoningReplayed(t *testing.T) {
+	model := "gpt-5.6-luna"
+	firstOutput := strings.Join([]string{
+		outputReasoningJSON("rs_1", "encrypted-reasoning"),
+		outputFunctionCallJSON("fc_1", "call_1", "get_weather", `{"location":"Lisbon"}`),
+	}, ",")
+	mockAPI := &mockResponses{
+		t: t,
+		responses: []*responses.Response{
+			responseFromJSON(t, responseJSON(model, firstOutput, responses.ResponseUsage{})),
+			responseFromJSON(t, responseJSON(model, outputMessageJSON("msg_2", "It is sunny."), responses.ResponseUsage{})),
+		},
+	}
+
+	rawClient, err := NewClient(&events.NoOpEventBus{}, WithResponsesClient(mockAPI))
+	require.NoError(t, err)
+	client := rawClient.(*Client)
+
+	handlerInvoked := false
+	prompt := ai.Prompt{
+		Name:      "weather",
+		Text:      "Weather?",
+		ModelName: model,
+		Functions: []*ai.FunctionDeclaration{{
+			Name: "get_weather",
+			Parameters: &ai.Schema{
+				Type: ai.TypeObject,
+			},
+		}},
+		Handlers: map[string]ai.HandlerFunc{
+			"get_weather": func(ctx context.Context, args map[string]any) (map[string]any, error) {
+				handlerInvoked = true
+				require.Equal(t, "Lisbon", args["location"])
+				return map[string]any{"summary": "Sunny"}, nil
+			},
+		},
+	}
+
+	resp, err := client.GenerateContent(context.Background(), prompt, false)
+	require.NoError(t, err)
+	assert.True(t, handlerInvoked)
+	assert.Equal(t, "It is sunny.", resp)
+
+	mockAPI.mu.Lock()
+	defer mockAPI.mu.Unlock()
+	require.Len(t, mockAPI.requests, 2)
+	secondInput := mockAPI.requests[1].Input.OfInputItemList
+	require.GreaterOrEqual(t, len(secondInput), 4)
+	require.NotNil(t, secondInput[1].OfReasoning)
+	require.True(t, secondInput[1].OfReasoning.EncryptedContent.Valid())
+	assert.Equal(t, "encrypted-reasoning", secondInput[1].OfReasoning.EncryptedContent.Value)
+	require.NotNil(t, secondInput[2].OfFunctionCall)
+	assert.Equal(t, "call_1", secondInput[2].OfFunctionCall.CallID)
+	require.NotNil(t, secondInput[3].OfFunctionCallOutput)
+	assert.Equal(t, "call_1", secondInput[3].OfFunctionCallOutput.CallID)
+	assert.JSONEq(t, `{"summary":"Sunny"}`, secondInput[3].OfFunctionCallOutput.Output)
+}
+
+func TestClient_Responses_StreamingOrder(t *testing.T) {
+	model := "gpt-5.6-luna"
+	usage := responses.ResponseUsage{InputTokens: 10, OutputTokens: 2, TotalTokens: 12}
+	firstCompleted := responseJSON(model, outputFunctionCallJSON("fc_1", "call_1", "run_tool", `{"task":"go"}`), usage)
+	secondCompleted := responseJSON(model, outputMessageJSON("msg_2", "done"), usage)
+	mockAPI := &mockResponses{
+		t: t,
+		streams: []string{
+			sseEvent(`{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"checking","sequence_number":1}`) +
+				sseEvent(fmt.Sprintf(`{"type":"response.completed","sequence_number":2,"response":%s}`, firstCompleted)),
+			sseEvent(`{"type":"response.output_text.delta","item_id":"msg_2","output_index":0,"content_index":0,"delta":"done","sequence_number":1}`) +
+				sseEvent(fmt.Sprintf(`{"type":"response.completed","sequence_number":2,"response":%s}`, secondCompleted)),
+		},
+	}
+
+	rawClient, err := NewClient(&events.NoOpEventBus{}, WithResponsesClient(mockAPI))
+	require.NoError(t, err)
+	client := rawClient.(*Client)
+
+	stream, err := client.GenerateContentStream(context.Background(), ai.Prompt{
+		Text:      "Run it.",
+		ModelName: model,
+		Functions: []*ai.FunctionDeclaration{{
+			Name:       "run_tool",
+			Parameters: &ai.Schema{Type: ai.TypeObject},
+		}},
+		Handlers: map[string]ai.HandlerFunc{
+			"run_tool": func(ctx context.Context, args map[string]any) (map[string]any, error) {
+				return map[string]any{"ok": true}, nil
+			},
+		},
+	}, false)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	var got []string
+	for {
+		chunk, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		switch {
+		case chunk.Text != "":
+			got = append(got, "text:"+chunk.Text)
+		case chunk.TokenCount != nil:
+			got = append(got, "usage")
+		case len(chunk.ToolCalls) > 0:
+			got = append(got, "tool:"+chunk.ToolCalls[0].ID)
+		}
+	}
+
+	assert.Equal(t, []string{"text:checking", "usage", "tool:call_1", "text:done", "usage"}, got)
+}
+
+func TestClient_TransportSelectionByModelGeneration(t *testing.T) {
+	chatMock := &mockChatCompletions{
+		t: t,
+		responses: []*openai.ChatCompletion{
+			newChatCompletion("chat", shared.ChatModelGPT4oMini, newChatCompletionMessage("chat path", nil), openai.CompletionUsage{}),
+		},
+	}
+	responsesMock := &mockResponses{
+		t: t,
+		responses: []*responses.Response{
+			responseFromJSON(t, responseJSON("gpt-5", outputMessageJSON("msg_1", "responses path"), responses.ResponseUsage{})),
+		},
+	}
+
+	rawClient, err := NewClient(&events.NoOpEventBus{}, WithChatClient(chatMock), WithResponsesClient(responsesMock))
+	require.NoError(t, err)
+	client := rawClient.(*Client)
+
+	chatResp, err := client.GenerateContent(context.Background(), ai.Prompt{Text: "hi", ModelName: string(shared.ChatModelGPT4oMini)}, false)
+	require.NoError(t, err)
+	assert.Equal(t, "chat path", chatResp)
+
+	responsesResp, err := client.GenerateContent(context.Background(), ai.Prompt{Text: "hi", ModelName: "gpt-5"}, false)
+	require.NoError(t, err)
+	assert.Equal(t, "responses path", responsesResp)
+
+	chatMock.mu.Lock()
+	require.Len(t, chatMock.requests, 1)
+	chatMock.mu.Unlock()
+	responsesMock.mu.Lock()
+	require.Len(t, responsesMock.requests, 1)
+	responsesMock.mu.Unlock()
+}

--- a/pkg/llm/openai/responses_turn.go
+++ b/pkg/llm/openai/responses_turn.go
@@ -1,0 +1,474 @@
+package openai
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	openai "github.com/openai/openai-go"
+	"github.com/openai/openai-go/responses"
+	"github.com/openai/openai-go/shared"
+
+	"github.com/kcaldas/genie/pkg/ai"
+	"github.com/kcaldas/genie/pkg/events"
+	llmshared "github.com/kcaldas/genie/pkg/llm/shared"
+	"github.com/kcaldas/genie/pkg/llm/shared/toolpayload"
+)
+
+type responsesTurnState struct {
+	client    *Client
+	params    responses.ResponseNewParams
+	input     responses.ResponseInputParam
+	modelName string
+	toolUsed  bool
+}
+
+func (c *Client) newResponsesTurn(prompt ai.Prompt, modelName string) (*responsesTurnState, error) {
+	instructions, err := c.buildInstructions(prompt)
+	if err != nil {
+		return nil, err
+	}
+	input := c.buildResponseInitialInput(prompt)
+
+	params := responses.ResponseNewParams{
+		Model:   shared.ResponsesModel(modelName),
+		Store:   openai.Bool(false),
+		Include: []responses.ResponseIncludable{responses.ResponseIncludableReasoningEncryptedContent},
+	}
+	if instructions != "" {
+		params.Instructions = openai.String(instructions)
+	}
+	params.Input = responses.ResponseNewParamsInputUnion{OfInputItemList: input}
+	c.applyResponsesGenerationConfig(&params, prompt)
+
+	return &responsesTurnState{
+		client:    c,
+		params:    params,
+		input:     input,
+		modelName: modelName,
+	}, nil
+}
+
+func (t *responsesTurnState) Step(ctx context.Context, emit func(*ai.StreamChunk)) (llmshared.StepOutcome, error) {
+	params := t.params
+	params.Input = responses.ResponseNewParamsInputUnion{OfInputItemList: t.input}
+
+	if emit != nil {
+		return t.stepStreaming(ctx, params, emit)
+	}
+	return t.stepBlocking(ctx, params)
+}
+
+func (t *responsesTurnState) stepBlocking(ctx context.Context, params responses.ResponseNewParams) (llmshared.StepOutcome, error) {
+	c := t.client
+	if c.responses == nil {
+		return llmshared.StepOutcome{}, errors.New("openai responses client not configured")
+	}
+
+	resp, err := c.responses.New(ctx, params)
+	if err != nil {
+		return llmshared.StepOutcome{}, fmt.Errorf("openai response: %w", err)
+	}
+
+	c.publishResponsesUsage(t.modelName, resp.Usage)
+	return t.recordResponse(resp, false, nil)
+}
+
+func (t *responsesTurnState) stepStreaming(ctx context.Context, params responses.ResponseNewParams, emit func(*ai.StreamChunk)) (llmshared.StepOutcome, error) {
+	c := t.client
+	if c.responses == nil {
+		return llmshared.StepOutcome{}, errors.New("openai responses client not configured")
+	}
+
+	stream := c.responses.NewStreaming(ctx, params)
+	defer stream.Close()
+
+	var completed *responses.Response
+	var eventToolCalls []responses.ResponseFunctionToolCall
+
+	for stream.Next() {
+		event := stream.Current()
+		switch event.Type {
+		case "response.output_text.delta":
+			if event.Delta.OfString != "" {
+				emit(&ai.StreamChunk{Text: event.Delta.OfString})
+			}
+		case "response.output_item.done":
+			if event.Item.Type == "function_call" {
+				eventToolCalls = append(eventToolCalls, event.Item.AsFunctionCall())
+			}
+		case "response.completed":
+			resp := event.Response
+			completed = &resp
+		case "response.failed", "response.incomplete":
+			if event.Response.Error.Message != "" {
+				return llmshared.StepOutcome{}, fmt.Errorf("openai response %s: %s", event.Response.Status, event.Response.Error.Message)
+			}
+			return llmshared.StepOutcome{}, fmt.Errorf("openai response %s", event.Response.Status)
+		case "error":
+			return llmshared.StepOutcome{}, fmt.Errorf("openai response stream error: %s", event.Message)
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		return llmshared.StepOutcome{}, fmt.Errorf("openai response stream: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return llmshared.StepOutcome{}, err
+	}
+	if completed == nil {
+		return llmshared.StepOutcome{}, errors.New("openai response stream returned no completed response")
+	}
+
+	if tc := c.publishResponsesUsage(t.modelName, completed.Usage); tc != nil {
+		emit(&ai.StreamChunk{TokenCount: tc})
+	}
+	outcome, err := t.recordResponse(completed, true, eventToolCalls)
+	if err != nil {
+		return llmshared.StepOutcome{}, err
+	}
+	if len(outcome.ToolCalls) > 0 {
+		emit(responseToolCallChunk(outcome.ToolCalls))
+	}
+	return outcome, nil
+}
+
+func (t *responsesTurnState) recordResponse(resp *responses.Response, streamed bool, streamedCalls []responses.ResponseFunctionToolCall) (llmshared.StepOutcome, error) {
+	if resp == nil {
+		return llmshared.StepOutcome{}, errors.New("openai response was nil")
+	}
+	if len(resp.Output) == 0 {
+		if t.toolUsed {
+			return llmshared.StepOutcome{}, nil
+		}
+		return llmshared.StepOutcome{}, errors.New("openai returned an empty response")
+	}
+
+	for _, item := range resp.Output {
+		if param, ok := responseOutputItemToInput(item); ok {
+			t.input = append(t.input, param)
+		}
+	}
+
+	text := responseOutputText(resp.Output)
+	toolCalls, err := responseToolCalls(resp.Output)
+	if err != nil {
+		return llmshared.StepOutcome{}, err
+	}
+	if len(toolCalls) == 0 && len(streamedCalls) > 0 {
+		toolCalls, err = responseToolCallsFromDoneEvents(streamedCalls)
+		if err != nil {
+			return llmshared.StepOutcome{}, err
+		}
+	}
+
+	if len(toolCalls) == 0 {
+		if strings.TrimSpace(text) == "" {
+			if t.toolUsed {
+				return llmshared.StepOutcome{}, nil
+			}
+			return llmshared.StepOutcome{}, errors.New("openai returned an empty response")
+		}
+		return llmshared.StepOutcome{Text: text}, nil
+	}
+
+	if text != "" && !streamed {
+		notification := events.NotificationEvent{Message: strings.TrimSpace(text)}
+		t.client.eventBus.Publish(notification.Topic(), notification)
+	}
+
+	t.toolUsed = true
+	return llmshared.StepOutcome{ToolCalls: toolCalls}, nil
+}
+
+func (t *responsesTurnState) AddToolResults(ctx context.Context, results []llmshared.ToolResult) error {
+	for _, result := range results {
+		handlerResp := result.Result
+		if result.Err != nil {
+			t.client.eventBus.Publish(events.NotificationEvent{}.Topic(), events.NotificationEvent{
+				Message: fmt.Sprintf("tool %s returned error: %v", result.Call.Name, result.Err),
+			})
+			handlerResp = map[string]any{
+				"error": fmt.Sprintf("function %q returned an error: %v", result.Call.Name, result.Err),
+			}
+		}
+
+		var media *toolpayload.Payload
+		switch result.Call.Name {
+		case "viewImage", "viewDocument":
+			extracted, sanitized, err := toolpayload.Extract(handlerResp)
+			if err != nil {
+				return fmt.Errorf("invalid %s response: %w", result.Call.Name, err)
+			}
+			handlerResp = sanitized
+			media = extracted
+		}
+
+		payload, err := json.Marshal(handlerResp)
+		if err != nil {
+			return fmt.Errorf("unable to marshal response for function %q: %w", result.Call.Name, err)
+		}
+		t.input = append(t.input, responses.ResponseInputItemUnionParam{
+			OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+				CallID: result.Call.ID,
+				Output: string(payload),
+			},
+		})
+
+		if media != nil {
+			switch result.Call.Name {
+			case "viewImage":
+				t.input = append(t.input, buildResponseImageUserMessage(media))
+			case "viewDocument":
+				t.input = append(t.input, buildResponseDocumentUserMessage(media))
+			}
+		}
+	}
+
+	return ctx.Err()
+}
+
+func (c *Client) buildResponseInitialInput(prompt ai.Prompt) responses.ResponseInputParam {
+	return responses.ResponseInputParam{c.buildResponseUserMessage(prompt.Text, prompt.Images)}
+}
+
+func (c *Client) buildResponseUserMessage(text string, images []*ai.Image) responses.ResponseInputItemUnionParam {
+	trimmed := strings.TrimSpace(text)
+	var parts []responses.ResponseInputContentUnionParam
+	if trimmed != "" {
+		parts = append(parts, responses.ResponseInputContentParamOfInputText(trimmed))
+	}
+	for _, img := range images {
+		if img == nil || len(img.Data) == 0 {
+			continue
+		}
+		mimeType := img.Type
+		if strings.TrimSpace(mimeType) == "" {
+			mimeType = "image/png"
+		}
+		dataURL := fmt.Sprintf("data:%s;base64,%s", mimeType, base64.StdEncoding.EncodeToString(img.Data))
+		image := responses.ResponseInputImageParam{
+			Detail:   responses.ResponseInputImageDetailAuto,
+			ImageURL: openai.String(dataURL),
+		}
+		parts = append(parts, responses.ResponseInputContentUnionParam{OfInputImage: &image})
+	}
+
+	return responses.ResponseInputItemUnionParam{
+		OfInputMessage: &responses.ResponseInputItemMessageParam{
+			Role:    "user",
+			Content: parts,
+		},
+	}
+}
+
+func (c *Client) applyResponsesGenerationConfig(params *responses.ResponseNewParams, prompt ai.Prompt) {
+	modelCfg := c.config.GetModelConfig()
+	targetModel := string(params.Model)
+	allowSampling := allowsSamplingParams(targetModel)
+
+	maxTokens := prompt.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = modelCfg.MaxTokens
+	}
+	if maxTokens > 0 {
+		params.MaxOutputTokens = openai.Int(int64(maxTokens))
+	}
+
+	if allowSampling {
+		temperature := prompt.Temperature
+		if temperature <= 0 {
+			temperature = modelCfg.Temperature
+		}
+		if temperature > 0 {
+			params.Temperature = openai.Float(float64(temperature))
+			topP := prompt.TopP
+			if supportsTopP(targetModel) && topP > 0 && math.Abs(float64(topP)-1.0) > 1e-6 {
+				params.TopP = openai.Float(float64(topP))
+			} else if topP > 0 && math.Abs(float64(topP)-1.0) > 1e-6 {
+				c.logger.Debug("top_p not supported for model; using default", "model", targetModel)
+			}
+		}
+	} else {
+		if prompt.Temperature > 0 && prompt.Temperature != 1.0 {
+			c.logger.Debug("temperature not supported for model; using default", "model", targetModel)
+		}
+		if prompt.TopP > 0 && prompt.TopP != 1.0 {
+			c.logger.Debug("top_p not supported for model; using default", "model", targetModel)
+		}
+	}
+
+	if len(prompt.Functions) > 0 {
+		params.Tools = mapResponseFunctions(prompt.Functions)
+		params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+			OfToolChoiceMode: openai.Opt(responses.ToolChoiceOptionsAuto),
+		}
+	}
+
+	if prompt.ResponseSchema != nil {
+		params.Text = responses.ResponseTextConfigParam{
+			Format: responses.ResponseFormatTextConfigUnionParam{
+				OfJSONSchema: &responses.ResponseFormatTextJSONSchemaConfigParam{
+					Name:   chooseSchemaName(prompt),
+					Schema: schemaToMap(prompt.ResponseSchema),
+					Strict: openai.Bool(true),
+				},
+			},
+		}
+	}
+}
+
+func responseOutputItemToInput(item responses.ResponseOutputItemUnion) (responses.ResponseInputItemUnionParam, bool) {
+	switch item.Type {
+	case "message":
+		msg := item.AsMessage().ToParam()
+		return responses.ResponseInputItemUnionParam{OfOutputMessage: &msg}, true
+	case "function_call":
+		call := item.AsFunctionCall()
+		param := responses.ResponseFunctionToolCallParam{
+			Arguments: call.Arguments,
+			CallID:    call.CallID,
+			Name:      call.Name,
+			Status:    call.Status,
+		}
+		if call.ID != "" {
+			param.ID = openai.String(call.ID)
+		}
+		return responses.ResponseInputItemUnionParam{OfFunctionCall: &param}, true
+	case "reasoning":
+		reasoning := item.AsReasoning()
+		if strings.TrimSpace(reasoning.EncryptedContent) == "" {
+			return responses.ResponseInputItemUnionParam{}, false
+		}
+		summary := make([]responses.ResponseReasoningItemSummaryParam, 0, len(reasoning.Summary))
+		for _, part := range reasoning.Summary {
+			summary = append(summary, responses.ResponseReasoningItemSummaryParam{Text: part.Text})
+		}
+		param := responses.ResponseReasoningItemParam{
+			ID:               reasoning.ID,
+			Summary:          summary,
+			EncryptedContent: openai.String(reasoning.EncryptedContent),
+			Status:           reasoning.Status,
+		}
+		return responses.ResponseInputItemUnionParam{OfReasoning: &param}, true
+	default:
+		return responses.ResponseInputItemUnionParam{}, false
+	}
+}
+
+func responseOutputText(output []responses.ResponseOutputItemUnion) string {
+	var b strings.Builder
+	for _, item := range output {
+		if item.Type != "message" {
+			continue
+		}
+		msg := item.AsMessage()
+		for _, part := range msg.Content {
+			if part.Type == "output_text" {
+				b.WriteString(part.Text)
+			}
+		}
+	}
+	return b.String()
+}
+
+func responseToolCalls(output []responses.ResponseOutputItemUnion) ([]llmshared.ToolCall, error) {
+	calls := make([]llmshared.ToolCall, 0)
+	for _, item := range output {
+		if item.Type != "function_call" {
+			continue
+		}
+		call := item.AsFunctionCall()
+		sharedCall, err := responseFunctionToolCallToShared(call)
+		if err != nil {
+			return nil, err
+		}
+		calls = append(calls, sharedCall)
+	}
+	return calls, nil
+}
+
+func responseToolCallsFromDoneEvents(calls []responses.ResponseFunctionToolCall) ([]llmshared.ToolCall, error) {
+	out := make([]llmshared.ToolCall, 0, len(calls))
+	for _, call := range calls {
+		sharedCall, err := responseFunctionToolCallToShared(call)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sharedCall)
+	}
+	return out, nil
+}
+
+func responseFunctionToolCallToShared(call responses.ResponseFunctionToolCall) (llmshared.ToolCall, error) {
+	args := map[string]any{}
+	if strings.TrimSpace(call.Arguments) != "" {
+		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
+			return llmshared.ToolCall{}, fmt.Errorf("invalid arguments for function %q: %w", call.Name, err)
+		}
+	}
+	return llmshared.ToolCall{ID: call.CallID, Name: call.Name, Args: args}, nil
+}
+
+func buildResponseImageUserMessage(img *toolpayload.Payload) responses.ResponseInputItemUnionParam {
+	text := toolpayload.SanitizePath(img.Path)
+	return (&Client{}).buildResponseUserMessage(fmt.Sprintf("Image retrieved from %s", text), []*ai.Image{
+		{Type: img.MIMEType, Data: img.Data},
+	})
+}
+
+func buildResponseDocumentUserMessage(doc *toolpayload.Payload) responses.ResponseInputItemUnionParam {
+	text := toolpayload.SanitizePath(doc.Path)
+	content := fmt.Sprintf("Document retrieved from %s (MIME: %s, %d bytes).", text, doc.MIMEType, doc.SizeBytes)
+	notice := "This provider does not support inline PDFs; refer to the tool response for access."
+	return (&Client{}).buildResponseUserMessage(content+"\n\n"+notice, nil)
+}
+
+func responseToolCallChunk(calls []llmshared.ToolCall) *ai.StreamChunk {
+	toolChunks := make([]*ai.ToolCallChunk, 0, len(calls))
+	for _, call := range calls {
+		toolChunks = append(toolChunks, &ai.ToolCallChunk{
+			ID:         call.ID,
+			Name:       call.Name,
+			Parameters: call.Args,
+		})
+	}
+	return &ai.StreamChunk{ToolCalls: toolChunks}
+}
+
+func (c *Client) publishResponsesUsage(modelName string, usage responses.ResponseUsage) *ai.TokenCount {
+	if usage.TotalTokens == 0 && usage.InputTokens == 0 && usage.OutputTokens == 0 {
+		return nil
+	}
+
+	cached := int32(usage.InputTokensDetails.CachedTokens)
+	if strings.TrimSpace(modelName) == "" {
+		modelName = c.resolveModelName("")
+	}
+	event := events.TokenCountEvent{
+		Provider:             "openai",
+		Model:                modelName,
+		InputTokens:          int32(usage.InputTokens) - cached,
+		OutputTokens:         int32(usage.OutputTokens),
+		CachedTokens:         cached,
+		CacheReadInputTokens: cached,
+		TotalTokens:          int32(usage.TotalTokens),
+	}
+	c.eventBus.Publish(event.Topic(), event)
+
+	if c.config.GetBoolWithDefault("GENIE_TOKEN_DEBUG", false) {
+		raw, _ := json.MarshalIndent(usage, "", "  ")
+		notification := events.NotificationEvent{Message: string(raw)}
+		c.eventBus.Publish(notification.Topic(), notification)
+	}
+
+	return &ai.TokenCount{
+		TotalTokens:  int32(usage.TotalTokens),
+		InputTokens:  int32(usage.InputTokens),
+		OutputTokens: int32(usage.OutputTokens),
+	}
+}

--- a/pkg/llm/openai/turn.go
+++ b/pkg/llm/openai/turn.go
@@ -28,8 +28,7 @@ type turnState struct {
 	toolUsed bool
 }
 
-func (c *Client) newTurn(prompt ai.Prompt) (*turnState, error) {
-	modelName := c.resolveModelName(prompt.ModelName)
+func (c *Client) newChatTurn(prompt ai.Prompt, modelName string) (*turnState, error) {
 	messages, _, err := c.buildMessages(prompt)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- route GPT-5 and newer OpenAI models through `/v1/responses` while retaining Chat Completions for older generations
- preserve stateless reasoning and tool-call history, streaming order, usage publication, and token counting
- default to Gemini 3.6 Flash and refresh static model context-window fallbacks

## Tests
- `go test ./...`