### PR TITLE
fix(openai): omit sampling params from gpt-5 and newer

### DIFF
--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -605,7 +605,22 @@ type tokenMessage struct {
 	Name    string
 }
 
+// allowsSamplingParams reports whether the model still accepts temperature and
+// top_p. OpenAI retired them from gpt-5 onward: a request carrying temperature
+// returns 400 "Unsupported parameter: 'temperature' is not supported with this
+// model", on /v1/responses and chat/completions alike, so the turn fails
+// outright rather than degrading.
+//
+// The test is the generation, not a name list, so a family released tomorrow
+// is covered — and it shares gptGeneration with useResponsesAPI, so the two
+// cannot drift apart. Models that are not OpenAI's own (OpenAI-compatible
+// endpoints reached through OPENAI_BASE_URL) keep their previous behaviour:
+// this is about OpenAI's generations, not about every server speaking its
+// protocol.
 func allowsSamplingParams(model string) bool {
+	if version, ok := gptGeneration(model); ok {
+		return version < 5
+	}
 	model = strings.ToLower(strings.TrimSpace(model))
 	switch {
 	case strings.HasPrefix(model, "o1"),

--- a/pkg/llm/openai/reasoning_test.go
+++ b/pkg/llm/openai/reasoning_test.go
@@ -47,3 +47,32 @@ func TestUseResponsesAPI(t *testing.T) {
 		}
 	}
 }
+
+// gpt-5.6 answers a request carrying temperature with
+// 400 "Unsupported parameter: 'temperature' is not supported with this model",
+// on both /v1/responses and chat/completions. The gate keys on the generation
+// rather than a name list, and deliberately leaves non-OpenAI models routed
+// through this client (OpenAI-compatible endpoints) alone.
+func TestAllowsSamplingParamsByGeneration(t *testing.T) {
+	for _, tc := range []struct {
+		model string
+		want  bool
+	}{
+		{"gpt-5.6-luna", false},
+		{"gpt-5", false},
+		{"gpt-6-mini", false},
+		{"gpt-4o", true},
+		{"gpt-4o-mini", true},
+		{"gpt-4.1-mini", true},
+		{"gpt-3.5-turbo", true},
+		{"o1-preview", false},
+		{"o4-mini", false},
+		// Third-party models reached through OPENAI_BASE_URL keep whatever
+		// they had; this change is about OpenAI's own generations.
+		{"deepseek-v4-flash", true},
+	} {
+		if got := allowsSamplingParams(tc.model); got != tc.want {
+			t.Errorf("allowsSamplingParams(%q) = %v, want %v", tc.model, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Pinning a hosted agent to `gpt-5.6-luna` fails on the first model call:

```
POST https://api.openai.com/v1/responses
400: Unsupported parameter: 'temperature' is not supported with this model.
```

`allowsSamplingParams` is a blocklist — `o1`/`o3`/`o4` denied, everything else allowed — so the Responses request carries `temperature` and the turn dies. Both the chat and Responses paths share the gate, so both fail.

#22 called this out and deliberately left it:

> a future OpenAI model that retires temperature will fail the same way Anthropic just did. Left alone because inverting it changes behaviour for every model in use today and no OpenAI model has been observed rejecting the field yet.

`gpt-5.6-luna` is that observation.

## What

Gate on the generation, reusing `gptGeneration` — the same parse `useResponsesAPI` uses, so the sampling rule cannot drift from the routing rule:

- `gpt-5`, `gpt-5.6-luna`, and any future `gpt-6+` → omit
- `gpt-4o`, `gpt-4.1`, `gpt-3.5` → unchanged
- `o1`/`o3`/`o4` → unchanged (still denied)
- **Non-OpenAI models** reached through `OPENAI_BASE_URL` (DeepSeek and other compatible endpoints) → unchanged. This is about OpenAI's generations, not every server speaking its protocol — that distinction is what makes the inversion safe.

## Tests

Table over all of the above, including a hypothetical `gpt-6-mini` for the future-family case and `deepseek-v4-flash` for the third-party case.

## Note

Mutiro can work around this today by setting `GENIE_MODEL_TEMPERATURE=0` as an agent secret, which makes the persona render `temperature: 0` and the client skip the field. That is a workaround for a model that should never have been sent the parameter.