### PR TITLE
feat(telemetry): tool, model-step, and subagent spans + trace-stamped session entries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
+	go.opentelemetry.io/otel v1.35.0
+	go.opentelemetry.io/otel/trace v1.35.0
 	google.golang.org/genai v1.46.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -101,9 +103,7 @@ require (
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
-	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
-	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,7 +116,6 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
-github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -266,8 +265,6 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/mod v0.29.0 h1:HV8lRxZC4l2cr3Zq1LvtOsi/ThTgWnUk/y64QSs8GwA=
-golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -334,8 +331,6 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
-golang.org/x/tools v0.38.0 h1:Hx2Xv8hISq8Lm16jvBZ2VQf+RLmbd7wVUsALibYI/IQ=
-golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/pkg/genie/core.go
+++ b/pkg/genie/core.go
@@ -1,6 +1,8 @@
 package genie
 
 import (
+	oteltrace "go.opentelemetry.io/otel/trace"
+
 	"context"
 	"encoding/json"
 	"fmt"
@@ -611,6 +613,13 @@ func (g *core) processChat(ctx context.Context, message string, options chatRequ
 	ctx = applySessionContext(ctx, sess)
 	if options.requestID != "" {
 		ctx = context.WithValue(ctx, requestIDContextKey{}, options.requestID)
+		if g.recorder != nil {
+			traceID := ""
+			if sc := oteltrace.SpanContextFromContext(ctx); sc.IsValid() {
+				traceID = sc.TraceID().String()
+			}
+			g.recorder.SetTraceID(traceID)
+		}
 	}
 
 	// Create prompt context with structured context parts + message

--- a/pkg/llm/shared/driver.go
+++ b/pkg/llm/shared/driver.go
@@ -1,6 +1,12 @@
 package shared
 
 import (
+	"github.com/google/uuid"
+	"github.com/kcaldas/genie/pkg/telemetry"
+	"github.com/kcaldas/genie/pkg/toolctx"
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
 	"context"
 	"fmt"
 	"log"
@@ -167,7 +173,13 @@ func stepWithRetry(ctx context.Context, turn TurnState, cfg LoopConfig, emit fun
 
 	backoff := cfg.StepBackoff
 	for attempt := 0; ; attempt++ {
-		outcome, err = turn.Step(ctx, emit)
+		stepCtx, span := telemetry.Tracer().Start(ctx, "genie.model_step",
+			oteltrace.WithAttributes(attribute.Int("genie.attempt", attempt)))
+		outcome, err = turn.Step(stepCtx, emit)
+		if err != nil {
+			span.RecordError(err)
+		}
+		span.End()
 		if err == nil {
 			return outcome, nil
 		}
@@ -205,7 +217,25 @@ func executeToolCalls(ctx context.Context, bus events.EventBus, calls []ToolCall
 			continue
 		}
 
-		output, err := handler(ctx, call.Args)
+		// One execution ID and one span per tool call: the ID correlates
+		// the tool lifecycle events and session-recorder entries, the span
+		// nests the call under the turn's trace.
+		callCtx := ctx
+		executionID, hasID := toolctx.ExecutionID(callCtx)
+		if !hasID || executionID == "" {
+			executionID = uuid.New().String()
+			callCtx = toolctx.WithExecutionID(callCtx, executionID)
+		}
+		callCtx, span := telemetry.Tracer().Start(callCtx, "genie.tool",
+			oteltrace.WithAttributes(
+				attribute.String("genie.tool_name", call.Name),
+				attribute.String("genie.execution_id", executionID),
+			))
+		output, err := handler(callCtx, call.Args)
+		if err != nil {
+			span.RecordError(err)
+		}
+		span.End()
 		results = append(results, prepareToolResult(bus, call, output, err, limits, budget))
 	}
 	return results

--- a/pkg/llm/shared/tool_tracing_test.go
+++ b/pkg/llm/shared/tool_tracing_test.go
@@ -1,0 +1,49 @@
+package shared
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kcaldas/genie/pkg/ai"
+	"github.com/kcaldas/genie/pkg/toolctx"
+)
+
+// Every tool call gets a real execution ID from the loop — no more
+// "unknown" in tool lifecycle events for tools that don't mint their own.
+func TestExecuteToolCallsAssignsExecutionID(t *testing.T) {
+	seen := map[string]string{}
+	handler := func(ctx context.Context, _ map[string]any) (ai.ToolOutput, error) {
+		id, ok := toolctx.ExecutionID(ctx)
+		if !ok || id == "" {
+			t.Fatal("handler ctx has no execution ID")
+		}
+		seen[id] = id
+		return ai.ToolOutput{}, nil
+	}
+
+	executeToolCalls(context.Background(), nil,
+		[]ToolCall{{Name: "a"}, {Name: "a"}},
+		map[string]ai.HandlerFunc{"a": handler}, ToolResultLimits{})
+
+	if len(seen) != 2 {
+		t.Fatalf("expected 2 distinct execution IDs, got %d", len(seen))
+	}
+}
+
+// A caller-provided execution ID is respected, not replaced.
+func TestExecuteToolCallsKeepsCallerExecutionID(t *testing.T) {
+	got := ""
+	handler := func(ctx context.Context, _ map[string]any) (ai.ToolOutput, error) {
+		got, _ = toolctx.ExecutionID(ctx)
+		return ai.ToolOutput{}, nil
+	}
+
+	ctx := toolctx.WithExecutionID(context.Background(), "preset-id")
+	executeToolCalls(ctx, nil,
+		[]ToolCall{{Name: "a"}},
+		map[string]ai.HandlerFunc{"a": handler}, ToolResultLimits{})
+
+	if got != "preset-id" {
+		t.Fatalf("execution ID = %q, want preset-id", got)
+	}
+}

--- a/pkg/session/entry.go
+++ b/pkg/session/entry.go
@@ -45,6 +45,9 @@ type Base struct {
 	ID        string `json:"id"`
 	ParentID  string `json:"parentId,omitempty"`
 	Timestamp string `json:"timestamp"`
+	// TraceID joins the entry to the distributed trace of the turn that
+	// produced it, when the host process runs with tracing.
+	TraceID string `json:"traceId,omitempty"`
 }
 
 // Field is a capped, redactable text excerpt. Truncated fields keep the

--- a/pkg/session/recorder.go
+++ b/pkg/session/recorder.go
@@ -40,6 +40,7 @@ type Recorder struct {
 	turnEntries int
 	turnSkipped int
 	closed      bool
+	traceID     string
 
 	// lastContext holds each context part's previous hash (and, when
 	// content deltas are recorded, its content — the basis for the next
@@ -199,12 +200,27 @@ func orderedPartNames(parts map[string]string, wireOrder []string) []string {
 	return append(names, rest...)
 }
 
+// SetTraceID sets the distributed-trace ID stamped on subsequently
+// appended entries ("" clears it). The host sets it at turn start so every
+// recorded entry of the turn joins the turn's trace.
+func (r *Recorder) SetTraceID(traceID string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.traceID = traceID
+	r.mu.Unlock()
+}
+
 // appendLocked writes one entry under the caller-held lock, enforcing
 // the per-turn entry cap like append.
 func (r *Recorder) appendLocked(entryType string, base *Base, entry any) {
 	if r.turnEntries >= r.caps.maxEntriesPerTurn {
 		r.turnSkipped++
 		return
+	}
+	if base.TraceID == "" {
+		base.TraceID = r.traceID
 	}
 	if r.writeLocked(entryType, base, entry) {
 		r.turnEntries++

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,0 +1,36 @@
+// Package telemetry exposes genie's tracer and W3C trace-context helpers.
+// Spans come from the global OpenTelemetry provider: they are no-ops unless
+// the host process initializes one, so genie itself configures no exporter
+// and adds no overhead for uninstrumented hosts.
+package telemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// Tracer returns genie's tracer from the global provider.
+func Tracer() oteltrace.Tracer {
+	return otel.Tracer("genie")
+}
+
+// Traceparent serializes ctx's span context to a W3C traceparent value,
+// or "" when ctx carries no valid span.
+func Traceparent(ctx context.Context) string {
+	carrier := propagation.MapCarrier{}
+	propagation.TraceContext{}.Inject(ctx, carrier)
+	return carrier["traceparent"]
+}
+
+// SpanContextFromTraceparent parses a W3C traceparent value; the zero
+// SpanContext (IsValid() == false) when tp is empty or malformed.
+func SpanContextFromTraceparent(tp string) oteltrace.SpanContext {
+	if tp == "" {
+		return oteltrace.SpanContext{}
+	}
+	ctx := propagation.TraceContext{}.Extract(context.Background(), propagation.MapCarrier{"traceparent": tp})
+	return oteltrace.SpanContextFromContext(ctx)
+}

--- a/pkg/tools/bash.go
+++ b/pkg/tools/bash.go
@@ -129,11 +129,13 @@ Usage notes:
 // Handler returns the function handler for the bash tool
 func (b *BashTool) Handler() ai.HandlerFunc {
 	return func(ctx context.Context, params map[string]any) (ai.ToolOutput, error) {
-		// Generate execution ID for this tool execution
-		executionID := uuid.New().String()
-
-		// Add execution ID to context
-		ctx = toolctx.WithExecutionID(ctx, executionID)
+		// Reuse the execution ID assigned by the tool loop; generate one
+		// only when invoked outside it.
+		executionID, hasID := toolctx.ExecutionID(ctx)
+		if !hasID || executionID == "" {
+			executionID = uuid.New().String()
+			ctx = toolctx.WithExecutionID(ctx, executionID)
+		}
 
 		// Extract command parameter
 		command, ok := params["command"].(string)

--- a/pkg/tools/task.go
+++ b/pkg/tools/task.go
@@ -1,6 +1,10 @@
 package tools
 
 import (
+	"github.com/kcaldas/genie/pkg/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -248,6 +252,21 @@ func (m *TaskManager) Start(request TaskRequest) (TaskSnapshot, error) {
 	dedupe := taskDedupeKey(request)
 
 	ctx, cancel := context.WithTimeout(context.Background(), request.Timeout)
+	// The task deliberately detaches from the parent turn's lifetime; its
+	// span is a new root *linked* to the parent turn, so the trace walk
+	// survives the detachment without coupling cancellation.
+	spanOpts := []oteltrace.SpanStartOption{
+		oteltrace.WithNewRoot(),
+		oteltrace.WithAttributes(
+			attribute.String("genie.task_id", request.TaskID),
+			attribute.String("genie.task_summary", request.Summary),
+		),
+	}
+	if parent := telemetry.SpanContextFromTraceparent(request.Metadata[taskTraceparentMetadataKey]); parent.IsValid() {
+		spanOpts = append(spanOpts, oteltrace.WithLinks(oteltrace.Link{SpanContext: parent}))
+	}
+	ctx, taskSpan := telemetry.Tracer().Start(ctx, "genie.subagent_task", spanOpts...)
+	_ = taskSpan
 
 	record := &taskRecord{
 		request: request,
@@ -328,7 +347,12 @@ func (m *TaskManager) Cancel(taskID string) (TaskSnapshot, bool) {
 }
 
 func (m *TaskManager) run(ctx context.Context, request TaskRequest, reporter TaskReporter) {
+	taskSpan := oteltrace.SpanFromContext(ctx)
 	result, err := m.executor.RunTask(ctx, request, reporter)
+	if err != nil {
+		taskSpan.RecordError(err)
+	}
+	taskSpan.End()
 	status := TaskStatusCompleted
 	errText := strings.TrimSpace(result.Error)
 
@@ -434,6 +458,11 @@ func nextTaskID() string {
 	n := atomic.AddUint64(&taskIDCounter, 1)
 	return fmt.Sprintf("task_%x_%d", time.Now().UnixNano(), n)
 }
+
+// taskTraceparentMetadataKey carries the parent turn's W3C traceparent on a
+// task request; excluded from dedupe by construction (dedupe hashes only
+// summary/prompt/workspace/persona).
+const taskTraceparentMetadataKey = "traceparent"
 
 func taskDedupeKey(request TaskRequest) string {
 	normalized := strings.Join([]string{
@@ -606,6 +635,10 @@ func (t *TaskTool) handleStart(ctx context.Context, params map[string]any) (ai.T
 		Timeout:        timeout,
 		MaxOutputChars: maxOutput,
 		CreatedAt:      time.Now(),
+	}
+	// Carry the parent turn's trace so the detached task links back to it.
+	if tp := telemetry.Traceparent(ctx); tp != "" {
+		request.Metadata = map[string]string{taskTraceparentMetadataKey: tp}
 	}
 
 	snapshot, err := t.manager.Start(request)


### PR DESCRIPTION
Genie side of Mutiro's message-path tracing (mutiro docs/plans/message-path-tracing.md): with the host initializing a trace provider and passing a turn ctx, every tool call, model step, and subagent task nests under the turn's trace, and session-recorder entries carry the trace ID.

- **Inert by default**: spans use the global OTel provider — no exporter configured here, no-ops for uninstrumented hosts. No behavior change to tool execution, retries, or task lifetimes.
- **Tool loop** assigns a per-call execution ID (previously only bash set one; every other tool recorded `"unknown"` in lifecycle events) and wraps each call in a `genie.tool` span. Caller-provided IDs are respected (test covers both).
- **Model steps** get a `genie.model_step` span per attempt at `stepWithRetry` — one chokepoint, all providers.
- **Subagent tasks** stay lifetime-detached but start a `genie.subagent_task` root span *linked* to the parent turn (traceparent rides task metadata; dedupe hashes only summary/prompt/workspace/persona, so dedupe is unaffected).
- **Session recorder**: optional `traceId` on every entry via `Recorder.SetTraceID`, set at turn start.

Full test suite green; `go vet` clean.