### PR TITLE
feat(genie): expose WithRequestID chat option

### DIFF
--- a/pkg/ai/requestid.go
+++ b/pkg/ai/requestid.go
@@ -1,0 +1,30 @@
+package ai
+
+import "context"
+
+type requestIDContextKey struct{}
+
+// ContextWithRequestID returns a context carrying a chat invocation's request
+// ID. Genie attaches it before running a prompt so code executed on behalf of
+// the invocation — tool handlers, provider clients — can stamp the events it
+// publishes (for example token counts) with the invocation that caused them.
+// A blank ID leaves the context unchanged.
+func ContextWithRequestID(ctx context.Context, requestID string) context.Context {
+	if requestID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, requestIDContextKey{}, requestID)
+}
+
+// RequestIDFromContext returns the request ID attached by
+// ContextWithRequestID, or "" when none is set — for example on token counts
+// requested outside any chat invocation.
+func RequestIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if value, ok := ctx.Value(requestIDContextKey{}).(string); ok {
+		return value
+	}
+	return ""
+}

--- a/pkg/ai/requestid_test.go
+++ b/pkg/ai/requestid_test.go
@@ -1,0 +1,23 @@
+package ai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestIDContextRoundTrip(t *testing.T) {
+	ctx := ContextWithRequestID(context.Background(), "req-1")
+	assert.Equal(t, "req-1", RequestIDFromContext(ctx))
+}
+
+func TestRequestIDFromContextDefaults(t *testing.T) {
+	assert.Empty(t, RequestIDFromContext(context.Background()), "unset context yields empty ID")
+	assert.Empty(t, RequestIDFromContext(nil), "nil context yields empty ID") //nolint:staticcheck // nil-safety is part of the contract
+}
+
+func TestContextWithBlankRequestIDLeavesContextUnchanged(t *testing.T) {
+	base := context.Background()
+	assert.Equal(t, base, ContextWithRequestID(base, ""))
+}

--- a/pkg/genie/chat_options.go
+++ b/pkg/genie/chat_options.go
@@ -111,12 +111,19 @@ func WithPromptData(data map[string]string) ChatOption {
 // issue several Genie requests (for example a repair retry), each with its own
 // request ID mapped to the same turn. Uniqueness is the caller's
 // responsibility — Genie performs no deduplication, and concurrent invocations
-// sharing an ID are indistinguishable on the event stream. The ID is stored
-// verbatim in session records. A blank or whitespace-only value is ignored and
+// sharing an ID are indistinguishable on the event stream.
+//
+// A non-blank value is used byte-for-byte: it appears on events and in session
+// records exactly as supplied, surrounding whitespace included, so correlation
+// keys always match. A blank or whitespace-only value is treated as unset and
 // a UUID is generated as usual.
 func WithRequestID(requestID string) ChatOption {
 	return func(opts *chatRequestOptions) {
-		opts.requestID = strings.TrimSpace(requestID)
+		if strings.TrimSpace(requestID) == "" {
+			opts.requestID = ""
+			return
+		}
+		opts.requestID = requestID
 	}
 }
 

--- a/pkg/genie/chat_options.go
+++ b/pkg/genie/chat_options.go
@@ -100,6 +100,26 @@ func WithPromptData(data map[string]string) ChatOption {
 	}
 }
 
+// WithRequestID sets the correlation ID for this invocation. The ID appears
+// unchanged on the chat.started, chat.chunk, and chat.response events, in
+// session-recorder entries, and via RequestIDFromContext inside handlers.
+// Supplying it lets a caller register correlation state before calling Chat —
+// the started event is published before Chat returns, so an ID obtained any
+// later cannot be registered in time.
+//
+// This is an invocation ID, not an application turn ID: one logical turn may
+// issue several Genie requests (for example a repair retry), each with its own
+// request ID mapped to the same turn. Uniqueness is the caller's
+// responsibility — Genie performs no deduplication, and concurrent invocations
+// sharing an ID are indistinguishable on the event stream. The ID is stored
+// verbatim in session records. A blank or whitespace-only value is ignored and
+// a UUID is generated as usual.
+func WithRequestID(requestID string) ChatOption {
+	return func(opts *chatRequestOptions) {
+		opts.requestID = strings.TrimSpace(requestID)
+	}
+}
+
 func applyChatOptions(optionFns ...ChatOption) chatRequestOptions {
 	request := chatRequestOptions{
 		promptData: make(map[string]string),

--- a/pkg/genie/chat_request_id_test.go
+++ b/pkg/genie/chat_request_id_test.go
@@ -54,6 +54,27 @@ func TestChatWithRequestIDFlowsToLifecycleEvents(t *testing.T) {
 	}
 }
 
+// A non-blank supplied ID is used byte-for-byte — surrounding whitespace
+// included — so a caller's correlation key always matches what events carry.
+func TestChatWithPaddedRequestIDIsPreservedVerbatim(t *testing.T) {
+	fixture := genietest.NewTestFixture(t)
+	defer fixture.Cleanup()
+
+	fixture.StartAndGetSession()
+	message := "hello"
+	fixture.ExpectSimpleMessage(message, "hi")
+
+	paddedID := "  request-1 "
+	require.NoError(t, fixture.Genie.Chat(context.Background(), message,
+		genie.WithRequestID(paddedID)))
+
+	started := fixture.WaitForStartedEvent(2 * time.Second)
+	assert.Equal(t, paddedID, started.RequestID, "supplied ID must not be normalized")
+
+	response := fixture.WaitForResponseOrFail(2 * time.Second)
+	assert.Equal(t, paddedID, response.RequestID)
+}
+
 // Omitting the option, or supplying a blank/whitespace-only ID, must preserve
 // the existing behavior: Genie generates a UUID.
 func TestChatWithBlankRequestIDGeneratesUUID(t *testing.T) {

--- a/pkg/genie/chat_request_id_test.go
+++ b/pkg/genie/chat_request_id_test.go
@@ -1,0 +1,122 @@
+package genie_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kcaldas/genie/pkg/events"
+	"github.com/kcaldas/genie/pkg/genie"
+	"github.com/kcaldas/genie/pkg/genie/genietest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A caller-supplied request ID must reach every lifecycle surface unchanged:
+// the started event, streamed chunks (which read it from the request context),
+// and the response event.
+func TestChatWithRequestIDFlowsToLifecycleEvents(t *testing.T) {
+	fixture := genietest.NewTestFixture(t)
+	defer fixture.Cleanup()
+
+	fixture.StartAndGetSession()
+	message := "hello there"
+	fixture.ExpectSimpleMessage(message, "hi")
+
+	chunkChan := make(chan events.ChatChunkEvent, 4)
+	fixture.EventBus.Subscribe("chat.chunk", func(evt interface{}) {
+		if chunk, ok := evt.(events.ChatChunkEvent); ok {
+			chunkChan <- chunk
+		}
+	})
+
+	suppliedID := "mutiro-turn-42-attempt-1"
+	err := fixture.Genie.Chat(
+		context.Background(),
+		message,
+		genie.WithRequestID(suppliedID),
+		genie.WithStreaming(true),
+	)
+	require.NoError(t, err)
+
+	started := fixture.WaitForStartedEvent(2 * time.Second)
+	assert.Equal(t, suppliedID, started.RequestID, "started event must carry the supplied ID")
+
+	response := fixture.WaitForResponseOrFail(2 * time.Second)
+	assert.Equal(t, suppliedID, response.RequestID, "response event must carry the supplied ID")
+
+	select {
+	case chunk := <-chunkChan:
+		assert.Equal(t, suppliedID, chunk.RequestID, "chunk events must carry the supplied ID")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for chunk event")
+	}
+}
+
+// Omitting the option, or supplying a blank/whitespace-only ID, must preserve
+// the existing behavior: Genie generates a UUID.
+func TestChatWithBlankRequestIDGeneratesUUID(t *testing.T) {
+	for name, opts := range map[string][]genie.ChatOption{
+		"option omitted":  nil,
+		"whitespace only": {genie.WithRequestID("   ")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := genietest.NewTestFixture(t)
+			defer fixture.Cleanup()
+
+			fixture.StartAndGetSession()
+			message := "hello"
+			fixture.ExpectSimpleMessage(message, "hi")
+
+			require.NoError(t, fixture.Genie.Chat(context.Background(), message, opts...))
+
+			started := fixture.WaitForStartedEvent(2 * time.Second)
+			_, err := uuid.Parse(started.RequestID)
+			assert.NoError(t, err, "expected a generated UUID, got %q", started.RequestID)
+		})
+	}
+}
+
+// Two in-flight invocations must be attributable by request ID alone,
+// regardless of the order their response events arrive in.
+func TestChatConcurrentInvocationsCorrelateByRequestID(t *testing.T) {
+	fixture := genietest.NewTestFixture(t)
+	defer fixture.Cleanup()
+
+	fixture.StartAndGetSession()
+	fixture.ExpectMessages(map[string]string{
+		"first question":  "first answer",
+		"second question": "second answer",
+	})
+
+	responses := make(chan events.ChatResponseEvent, 2)
+	fixture.EventBus.Subscribe("chat.response", func(evt interface{}) {
+		if resp, ok := evt.(events.ChatResponseEvent); ok {
+			responses <- resp
+		}
+	})
+
+	pending := map[string]string{
+		"req-first":  "first answer",
+		"req-second": "second answer",
+	}
+	require.NoError(t, fixture.Genie.Chat(context.Background(), "first question",
+		genie.WithRequestID("req-first")))
+	require.NoError(t, fixture.Genie.Chat(context.Background(), "second question",
+		genie.WithRequestID("req-second")))
+
+	for range 2 {
+		select {
+		case resp := <-responses:
+			want, known := pending[resp.RequestID]
+			require.True(t, known, "response carried unknown request ID %q", resp.RequestID)
+			assert.Equal(t, want, resp.Response,
+				"request ID %q must select its own invocation's response", resp.RequestID)
+			delete(pending, resp.RequestID)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout; still unresolved: %v", pending)
+		}
+	}
+	assert.Empty(t, pending, "every supplied ID must be answered exactly once")
+}

--- a/pkg/genie/core.go
+++ b/pkg/genie/core.go
@@ -26,8 +26,6 @@ import (
 	"github.com/kcaldas/genie/pkg/tools"
 )
 
-type requestIDContextKey struct{}
-
 // PromptRunner executes prompts - allows mocking prompt execution for testing
 type PromptRunner interface {
 	RunPrompt(ctx context.Context, prompt *ai.Prompt, data map[string]string, eventBus events.EventBus) (string, error)
@@ -612,7 +610,7 @@ func (g *core) processChat(ctx context.Context, message string, options chatRequ
 	// author, genie_home) for tool handlers and prompt composition.
 	ctx = applySessionContext(ctx, sess)
 	if options.requestID != "" {
-		ctx = context.WithValue(ctx, requestIDContextKey{}, options.requestID)
+		ctx = ai.ContextWithRequestID(ctx, options.requestID)
 		if g.recorder != nil {
 			traceID := ""
 			if sc := oteltrace.SpanContextFromContext(ctx); sc.IsValid() {
@@ -902,21 +900,17 @@ func (s systemContext) userContext() string {
 }
 
 func requestIDFromContext(ctx context.Context) string {
-	if ctx == nil {
-		return ""
-	}
-	if value, ok := ctx.Value(requestIDContextKey{}).(string); ok {
-		return value
-	}
-	return ""
+	return ai.RequestIDFromContext(ctx)
 }
 
 // RequestIDFromContext returns the chat request ID attached to ctx by
 // Chat's WithRequestID option, or "" when none is set. It is exported
 // for PromptRunner implementations outside this package that need to
-// correlate streamed chunks with the originating request.
+// correlate streamed chunks with the originating request. The value
+// lives in pkg/ai so provider clients can read it too; this wrapper is
+// kept for compatibility with existing callers.
 func RequestIDFromContext(ctx context.Context) string {
-	return requestIDFromContext(ctx)
+	return ai.RequestIDFromContext(ctx)
 }
 
 // applySessionContext attaches per-tool-call values from the session to

--- a/pkg/genie/genietest/mock_prompt_runner.go
+++ b/pkg/genie/genietest/mock_prompt_runner.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/kcaldas/genie/pkg/ai"
 	"github.com/kcaldas/genie/pkg/events"
@@ -24,7 +25,13 @@ type MockResponse struct {
 	ToolCalls []MockToolCall
 }
 
+// MockPromptRunner is safe for concurrent use: Chat dispatches each request
+// on its own goroutine, so tests exercising concurrent invocations reach
+// RunPrompt in parallel. The mutex guards the expectation map and the
+// captured-argument slices; it is never held while executing mocked tool
+// calls, which publish events.
 type MockPromptRunner struct {
+	mu              sync.Mutex
 	responses       map[string]*MockResponse
 	eventBus        events.EventBus
 	capturedPrompts []*ai.Prompt
@@ -44,7 +51,9 @@ func (r *MockPromptRunner) ExpectMessage(message string) *MockResponseBuilder {
 		Response:  "", // Will be set by RespondWith
 		ToolCalls: []MockToolCall{},
 	}
+	r.mu.Lock()
 	r.responses[message] = mockResponse
+	r.mu.Unlock()
 
 	return &MockResponseBuilder{
 		runner:   r,
@@ -58,7 +67,9 @@ func (r *MockPromptRunner) ExpectSimpleMessage(message, response string) {
 		Response:  response,
 		ToolCalls: []MockToolCall{},
 	}
+	r.mu.Lock()
 	r.responses[message] = mockResponse
+	r.mu.Unlock()
 }
 
 type MockResponseBuilder struct {
@@ -93,6 +104,7 @@ func (t *MockToolBuilder) Returns(result map[string]any) *MockResponseBuilder {
 }
 
 func (r *MockPromptRunner) RunPrompt(ctx context.Context, prompt *ai.Prompt, data map[string]string, eventBus events.EventBus) (string, error) {
+	r.mu.Lock()
 	if prompt != nil {
 		copyPrompt := *prompt
 		r.capturedPrompts = append(r.capturedPrompts, &copyPrompt)
@@ -101,16 +113,14 @@ func (r *MockPromptRunner) RunPrompt(ctx context.Context, prompt *ai.Prompt, dat
 		dataCopy := maps.Clone(data)
 		r.capturedData = append(r.capturedData, dataCopy)
 	}
+	message, hasMessage := data["message"]
+	mockResponse, configured := r.responses[message]
+	r.mu.Unlock()
 
-	// Get the message from the prompt context
-	message, exists := data["message"]
-	if !exists {
+	if !hasMessage {
 		return "", fmt.Errorf("no message found in prompt context")
 	}
-
-	// Find the configured response for this message
-	mockResponse, exists := r.responses[message]
-	if !exists {
+	if !configured {
 		return "", fmt.Errorf("no mock response configured for message: %q", message)
 	}
 
@@ -172,11 +182,15 @@ func (r *MockPromptRunner) CountTokens(ctx context.Context, prompt *ai.Prompt, d
 
 // CapturedPrompts returns copies of the prompts captured during RunPrompt invocations.
 func (r *MockPromptRunner) CapturedPrompts() []*ai.Prompt {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return append([]*ai.Prompt(nil), r.capturedPrompts...)
 }
 
 // CapturedData returns copies of the prompt data arguments captured during RunPrompt invocations.
 func (r *MockPromptRunner) CapturedData() []map[string]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	copies := make([]map[string]string, 0, len(r.capturedData))
 	for _, data := range r.capturedData {
 		copies = append(copies, maps.Clone(data))

--- a/pkg/llm/anthropic/client.go
+++ b/pkg/llm/anthropic/client.go
@@ -227,7 +227,7 @@ func (c *Client) CountTokensAttr(ctx context.Context, prompt ai.Prompt, debug bo
 		TotalTokens: int32(result.InputTokens),
 		InputTokens: int32(result.InputTokens),
 	}
-	c.publishTokenCount(c.resolveModelName(prompt.ModelName), tokenCount)
+	c.publishTokenCount(ctx, c.resolveModelName(prompt.ModelName), tokenCount)
 	return tokenCount, nil
 }
 
@@ -654,7 +654,7 @@ func (c *Client) renderPrompt(prompt ai.Prompt, debug bool, attrs []ai.Attr) (*a
 	return llmshared.RenderPromptWithDebug(c.fileManager, prompt, debug, attrs)
 }
 
-func (c *Client) publishUsage(modelName string, usage anthropic_sdk.Usage) {
+func (c *Client) publishUsage(ctx context.Context, modelName string, usage anthropic_sdk.Usage) {
 	// Anthropic's InputTokens already excludes cached reads/writes; total billable
 	// input is InputTokens + CacheCreationInputTokens + CacheReadInputTokens.
 	cachedRead := int32(usage.CacheReadInputTokens)
@@ -664,6 +664,7 @@ func (c *Client) publishUsage(modelName string, usage anthropic_sdk.Usage) {
 		modelName = c.resolveModelName("")
 	}
 	event := events.TokenCountEvent{
+		RequestID:                ai.RequestIDFromContext(ctx),
 		Provider:                 "anthropic",
 		Model:                    modelName,
 		InputTokens:              int32(usage.InputTokens),
@@ -684,7 +685,7 @@ func (c *Client) publishUsage(modelName string, usage anthropic_sdk.Usage) {
 	}
 }
 
-func (c *Client) publishTokenCount(modelName string, tokenCount *ai.TokenCount) {
+func (c *Client) publishTokenCount(ctx context.Context, modelName string, tokenCount *ai.TokenCount) {
 	if tokenCount == nil {
 		return
 	}
@@ -692,6 +693,7 @@ func (c *Client) publishTokenCount(modelName string, tokenCount *ai.TokenCount) 
 		modelName = c.resolveModelName("")
 	}
 	event := events.TokenCountEvent{
+		RequestID:    ai.RequestIDFromContext(ctx),
 		Provider:     "anthropic",
 		Model:        modelName,
 		InputTokens:  tokenCount.InputTokens,

--- a/pkg/llm/anthropic/token_event_test.go
+++ b/pkg/llm/anthropic/token_event_test.go
@@ -1,0 +1,40 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	anthropic_sdk "github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kcaldas/genie/pkg/ai"
+	"github.com/kcaldas/genie/pkg/events"
+)
+
+// Usage events must carry the chat request ID attached to the context by the
+// core, so a host running concurrent invocations can attribute token spend.
+func TestPublishUsageCarriesRequestIDFromContext(t *testing.T) {
+	bus := events.NewEventBus()
+	received := make(chan events.TokenCountEvent, 1)
+	bus.Subscribe(events.TokenCountEvent{}.Topic(), func(evt interface{}) {
+		if event, ok := evt.(events.TokenCountEvent); ok {
+			received <- event
+		}
+	})
+
+	rawClient, err := NewClient(bus)
+	assert.NoError(t, err)
+	client := rawClient.(*Client)
+
+	ctx := ai.ContextWithRequestID(context.Background(), "req-7")
+	client.publishUsage(ctx, "claude-test", anthropic_sdk.Usage{InputTokens: 12, OutputTokens: 4})
+
+	select {
+	case event := <-received:
+		assert.Equal(t, "req-7", event.RequestID)
+		assert.Equal(t, "anthropic", event.Provider)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for token count event")
+	}
+}

--- a/pkg/llm/anthropic/turn.go
+++ b/pkg/llm/anthropic/turn.go
@@ -65,7 +65,7 @@ func (t *turnState) stepBlocking(ctx context.Context, params anthropic_sdk.Messa
 		return llmshared.StepOutcome{}, fmt.Errorf("anthropic messages: %w", err)
 	}
 
-	c.publishUsage(string(params.Model), resp.Usage)
+	c.publishUsage(ctx, string(params.Model), resp.Usage)
 	usage := physicalUsageTokenCount(resp.Usage)
 
 	showThinking := c.config.GetBoolWithDefault("ANTHROPIC_SHOW_THINKING", false)
@@ -143,7 +143,7 @@ func (t *turnState) stepStreaming(ctx context.Context, params anthropic_sdk.Mess
 		return llmshared.StepOutcome{}, err
 	}
 
-	c.publishUsage(string(params.Model), acc.Usage)
+	c.publishUsage(ctx, string(params.Model), acc.Usage)
 	usage := physicalUsageTokenCount(acc.Usage)
 	if tc := usageTokenCount(acc.Usage); tc != nil {
 		emit(&ai.StreamChunk{TokenCount: tc})

--- a/pkg/llm/genai/client.go
+++ b/pkg/llm/genai/client.go
@@ -547,7 +547,7 @@ func (g *Client) countTokensWithPrompt(ctx context.Context, p ai.Prompt) (*ai.To
 	return tokenCount, nil
 }
 
-func (g *Client) publishUsageMetadata(modelName string, usage *genai.GenerateContentResponseUsageMetadata) *ai.TokenCount {
+func (g *Client) publishUsageMetadata(ctx context.Context, modelName string, usage *genai.GenerateContentResponseUsageMetadata) *ai.TokenCount {
 	if usage == nil {
 		return nil
 	}
@@ -558,6 +558,7 @@ func (g *Client) publishUsageMetadata(modelName string, usage *genai.GenerateCon
 	// Subtract so InputTokens means "uncached input" — matches Anthropic's
 	// semantics so the cross-provider hit-rate math in the daemon works.
 	tokenCountEvent := events.TokenCountEvent{
+		RequestID:            ai.RequestIDFromContext(ctx),
 		Provider:             "gemini",
 		Model:                modelName,
 		InputTokens:          usage.PromptTokenCount - usage.CachedContentTokenCount,

--- a/pkg/llm/genai/turn.go
+++ b/pkg/llm/genai/turn.go
@@ -61,7 +61,7 @@ func (t *turnState) stepBlocking(ctx context.Context, emit func(*ai.StreamChunk)
 	if err != nil {
 		return llmshared.StepOutcome{}, fmt.Errorf("error generating content: %w", err)
 	}
-	usage := g.publishUsageMetadata(t.modelName, result.UsageMetadata)
+	usage := g.publishUsageMetadata(ctx, t.modelName, result.UsageMetadata)
 
 	// Malformed function calls: feed the failure back to the model and
 	// ask the loop to re-run the step.
@@ -160,7 +160,7 @@ func (t *turnState) stepStreaming(ctx context.Context, emit func(*ai.StreamChunk
 		return llmshared.StepOutcome{RetryStep: true}, nil
 	}
 
-	usage := g.publishUsageMetadata(t.modelName, lastUsageMetadata)
+	usage := g.publishUsageMetadata(ctx, t.modelName, lastUsageMetadata)
 	if usage != nil {
 		emit(&ai.StreamChunk{TokenCount: usage})
 	}

--- a/pkg/llm/lmstudio/client.go
+++ b/pkg/llm/lmstudio/client.go
@@ -187,7 +187,7 @@ func (c *Client) CountTokensAttr(ctx context.Context, prompt ai.Prompt, debug bo
 	}
 
 	tokenCount := c.buildTokenCount(response.Usage)
-	c.PublishTokenCount(tokenCount)
+	c.PublishTokenCount(ctx, tokenCount)
 
 	return tokenCount, nil
 }
@@ -550,7 +550,7 @@ func (c *Client) runStreamingChat(ctx context.Context, ch chan<- llmshared.Strea
 
 		if resp.Usage != nil {
 			tokenCount := c.buildTokenCount(resp.Usage)
-			c.PublishTokenCount(tokenCount)
+			c.PublishTokenCount(ctx, tokenCount)
 			if tokenCount != nil {
 				if err := c.emitStreamChunk(ctx, ch, &ai.StreamChunk{TokenCount: tokenCount}); err != nil {
 					return err

--- a/pkg/llm/lmstudio/turn.go
+++ b/pkg/llm/lmstudio/turn.go
@@ -60,7 +60,7 @@ func (t *turnState) Step(ctx context.Context, _ func(*ai.StreamChunk)) (llmshare
 	}
 
 	usage := c.buildTokenCount(response.Usage)
-	c.PublishTokenCount(usage)
+	c.PublishTokenCount(ctx, usage)
 
 	if len(response.Choices) == 0 {
 		return llmshared.StepOutcome{}, ai.NonRetryable(errEmptyResponse)

--- a/pkg/llm/ollama/client.go
+++ b/pkg/llm/ollama/client.go
@@ -144,7 +144,7 @@ func (c *Client) CountTokensAttr(ctx context.Context, prompt ai.Prompt, debug bo
 	}
 
 	tokenCount := c.buildTokenCount(response)
-	c.PublishTokenCount(tokenCount)
+	c.PublishTokenCount(ctx, tokenCount)
 
 	return tokenCount, nil
 }

--- a/pkg/llm/ollama/turn.go
+++ b/pkg/llm/ollama/turn.go
@@ -79,7 +79,7 @@ func (t *turnState) stepBlocking(ctx context.Context) (llmshared.StepOutcome, er
 	}
 
 	usage := c.buildTokenCount(response)
-	c.PublishTokenCount(usage)
+	c.PublishTokenCount(ctx, usage)
 
 	assistant := response.Message
 	assistantContent := strings.TrimSpace(assistant.Content.Text())
@@ -139,7 +139,7 @@ func (t *turnState) stepStreaming(ctx context.Context, emit func(*ai.StreamChunk
 
 		if resp.Done {
 			usage = c.buildTokenCount(resp)
-			c.PublishTokenCount(usage)
+			c.PublishTokenCount(ctx, usage)
 			if usage != nil {
 				emit(&ai.StreamChunk{TokenCount: usage})
 			}

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -212,7 +212,7 @@ func (c *Client) CountTokensAttr(ctx context.Context, prompt ai.Prompt, debug bo
 		TotalTokens: int32(total),
 		InputTokens: int32(total),
 	}
-	c.publishTokenCount(modelName, tokenCount)
+	c.publishTokenCount(ctx, modelName, tokenCount)
 
 	return tokenCount, nil
 }
@@ -513,7 +513,7 @@ func (c *Client) renderPrompt(prompt ai.Prompt, debug bool, attrs []ai.Attr) (*a
 	return llmshared.RenderPromptWithDebug(c.fileManager, prompt, debug, attrs)
 }
 
-func (c *Client) publishUsage(modelName string, usage openai.CompletionUsage) *ai.TokenCount {
+func (c *Client) publishUsage(ctx context.Context, modelName string, usage openai.CompletionUsage) *ai.TokenCount {
 	if usage.TotalTokens == 0 && usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
 		return nil
 	}
@@ -526,6 +526,7 @@ func (c *Client) publishUsage(modelName string, usage openai.CompletionUsage) *a
 		modelName = c.resolveModelName("")
 	}
 	event := events.TokenCountEvent{
+		RequestID:            ai.RequestIDFromContext(ctx),
 		Provider:             "openai",
 		Model:                modelName,
 		InputTokens:          int32(usage.PromptTokens) - cached,
@@ -550,7 +551,7 @@ func (c *Client) publishUsage(modelName string, usage openai.CompletionUsage) *a
 	}
 }
 
-func (c *Client) publishTokenCount(modelName string, tokenCount *ai.TokenCount) {
+func (c *Client) publishTokenCount(ctx context.Context, modelName string, tokenCount *ai.TokenCount) {
 	if tokenCount == nil {
 		return
 	}
@@ -558,6 +559,7 @@ func (c *Client) publishTokenCount(modelName string, tokenCount *ai.TokenCount) 
 		modelName = c.resolveModelName("")
 	}
 	event := events.TokenCountEvent{
+		RequestID:    ai.RequestIDFromContext(ctx),
 		Provider:     "openai",
 		Model:        modelName,
 		InputTokens:  tokenCount.InputTokens,

--- a/pkg/llm/openai/responses_turn.go
+++ b/pkg/llm/openai/responses_turn.go
@@ -75,7 +75,7 @@ func (t *responsesTurnState) stepBlocking(ctx context.Context, params responses.
 		return llmshared.StepOutcome{}, fmt.Errorf("openai response: %w", err)
 	}
 
-	usage := c.publishResponsesUsage(t.modelName, resp.Usage)
+	usage := c.publishResponsesUsage(ctx, t.modelName, resp.Usage)
 	outcome, err := t.recordResponse(resp, false, nil)
 	outcome.Usage = usage
 	return outcome, err
@@ -127,7 +127,7 @@ func (t *responsesTurnState) stepStreaming(ctx context.Context, params responses
 		return llmshared.StepOutcome{}, errors.New("openai response stream returned no completed response")
 	}
 
-	usage := c.publishResponsesUsage(t.modelName, completed.Usage)
+	usage := c.publishResponsesUsage(ctx, t.modelName, completed.Usage)
 	if usage != nil {
 		emit(&ai.StreamChunk{TokenCount: usage})
 	}
@@ -408,7 +408,7 @@ func responseToolCallChunk(calls []llmshared.ToolCall) *ai.StreamChunk {
 	return &ai.StreamChunk{ToolCalls: toolChunks}
 }
 
-func (c *Client) publishResponsesUsage(modelName string, usage responses.ResponseUsage) *ai.TokenCount {
+func (c *Client) publishResponsesUsage(ctx context.Context, modelName string, usage responses.ResponseUsage) *ai.TokenCount {
 	if usage.TotalTokens == 0 && usage.InputTokens == 0 && usage.OutputTokens == 0 {
 		return nil
 	}
@@ -418,6 +418,7 @@ func (c *Client) publishResponsesUsage(modelName string, usage responses.Respons
 		modelName = c.resolveModelName("")
 	}
 	event := events.TokenCountEvent{
+		RequestID:            ai.RequestIDFromContext(ctx),
 		Provider:             "openai",
 		Model:                modelName,
 		InputTokens:          int32(usage.InputTokens) - cached,

--- a/pkg/llm/openai/turn.go
+++ b/pkg/llm/openai/turn.go
@@ -65,7 +65,7 @@ func (t *turnState) stepBlocking(ctx context.Context, params openai.ChatCompleti
 		return llmshared.StepOutcome{}, fmt.Errorf("openai chat completion: %w", err)
 	}
 
-	usage := c.publishUsage(string(params.Model), resp.Usage)
+	usage := c.publishUsage(ctx, string(params.Model), resp.Usage)
 
 	if len(resp.Choices) == 0 {
 		if t.toolUsed {
@@ -203,7 +203,7 @@ func (t *turnState) stepStreaming(ctx context.Context, params openai.ChatComplet
 
 	var usage *ai.TokenCount
 	if lastUsage.TotalTokens != 0 || lastUsage.PromptTokens != 0 || lastUsage.CompletionTokens != 0 {
-		usage = c.publishUsage(string(params.Model), lastUsage)
+		usage = c.publishUsage(ctx, string(params.Model), lastUsage)
 		emit(&ai.StreamChunk{
 			TokenCount: &ai.TokenCount{
 				TotalTokens:  int32(lastUsage.TotalTokens),

--- a/pkg/llm/shared/localclient.go
+++ b/pkg/llm/shared/localclient.go
@@ -125,12 +125,14 @@ func (c *LocalClientCore) ResolveModelName(promptModel string) string {
 }
 
 // PublishTokenCount emits a TokenCountEvent for this provider. A nil
-// token count is ignored.
-func (c *LocalClientCore) PublishTokenCount(tokenCount *ai.TokenCount) {
+// token count is ignored. The event carries the chat request ID from ctx
+// when one is attached, so hosts can attribute usage per invocation.
+func (c *LocalClientCore) PublishTokenCount(ctx context.Context, tokenCount *ai.TokenCount) {
 	if tokenCount == nil {
 		return
 	}
 	event := events.TokenCountEvent{
+		RequestID:    ai.RequestIDFromContext(ctx),
 		Provider:     c.Provider,
 		Model:        c.ResolveModelName(""),
 		InputTokens:  tokenCount.InputTokens,

--- a/pkg/llm/shared/localclient_test.go
+++ b/pkg/llm/shared/localclient_test.go
@@ -1,0 +1,58 @@
+package shared
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kcaldas/genie/pkg/ai"
+	"github.com/kcaldas/genie/pkg/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Token events published by the local providers (Ollama, LM Studio) must
+// carry the chat request ID from the context so hosts can attribute usage
+// per invocation.
+func TestPublishTokenCountCarriesRequestIDFromContext(t *testing.T) {
+	bus := events.NewEventBus()
+	received := make(chan events.TokenCountEvent, 1)
+	bus.Subscribe(events.TokenCountEvent{}.Topic(), func(evt interface{}) {
+		if event, ok := evt.(events.TokenCountEvent); ok {
+			received <- event
+		}
+	})
+
+	core := NewLocalClientCore("ollama", bus)
+	ctx := ai.ContextWithRequestID(context.Background(), "req-9")
+	core.PublishTokenCount(ctx, &ai.TokenCount{InputTokens: 10, OutputTokens: 3, TotalTokens: 13})
+
+	select {
+	case event := <-received:
+		assert.Equal(t, "req-9", event.RequestID)
+		assert.Equal(t, "ollama", event.Provider)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for token count event")
+	}
+}
+
+// A token count requested outside any chat invocation carries no request ID.
+func TestPublishTokenCountWithoutRequestID(t *testing.T) {
+	bus := events.NewEventBus()
+	received := make(chan events.TokenCountEvent, 1)
+	bus.Subscribe(events.TokenCountEvent{}.Topic(), func(evt interface{}) {
+		if event, ok := evt.(events.TokenCountEvent); ok {
+			received <- event
+		}
+	})
+
+	core := NewLocalClientCore("lmstudio", bus)
+	core.PublishTokenCount(context.Background(), &ai.TokenCount{TotalTokens: 5})
+
+	select {
+	case event := <-received:
+		require.Empty(t, event.RequestID)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for token count event")
+	}
+}


### PR DESCRIPTION
## Summary

- export `WithRequestID(requestID string) ChatOption` so callers can supply the invocation correlation ID before calling `Chat` (#30)
- a non-blank ID is used **byte-for-byte** — it appears on events and in session records exactly as supplied, surrounding whitespace included, so correlation keys always match; blank or whitespace-only values fall back to the generated UUID, preserving current behavior
- populate `TokenCountEvent.RequestID`: the context key moves to `pkg/ai` (`ContextWithRequestID` / `RequestIDFromContext`), and every usage publisher — the shared local-client core (Ollama, LM Studio), Anthropic, Gemini, and both OpenAI paths — stamps token events with the request that caused them. `genie.RequestIDFromContext` remains as a compatibility wrapper. Token counts requested outside a chat invocation carry an empty ID.

## Why supplying beats returning

`ChatStartedEvent` is published before `Chat` returns, and the bus delivers asynchronously — an ID obtained from a return value can never be registered ahead of the started event. Supplying the ID up front is the only correct shape short of a `ChatAsync` request-handle API, which this change does not preclude.

The godoc pins the semantics from the issue: this is an **invocation** ID, not an application turn ID (one logical turn may issue several requests, e.g. a repair retry); uniqueness is the caller's responsibility — Genie performs no deduplication.

## Tests

- supplied ID appears unchanged on started, chunk (via the request context), and response events
- a padded ID (`"  request-1 "`) is preserved verbatim end to end
- omitted option and whitespace-only ID both yield a parseable generated UUID
- two concurrent invocations with distinct IDs are attributed by ID alone, independent of response arrival order
- token events carry the ctx request ID (shared local-client core + Anthropic), and an empty ID outside an invocation
- `pkg/ai` context round-trip, nil-context and blank-ID contracts
- `go build ./... && go vet ./... && go test -race ./...` clean (except the pre-existing env-dependent `TestClient_CountTokens` in `pkg/llm/genai`, which fails identically on `main` without a live Gemini endpoint)