### PR TITLE
Recent tool activity: pair each turn with a bounded digest of what it did

### DIFF
--- a/pkg/ai/tool_output.go
+++ b/pkg/ai/tool_output.go
@@ -8,6 +8,11 @@ type ToolOutput struct {
 	Content []ToolContent
 	Details map[string]any
 	IsError bool
+	// Sticky is the tool's retention hint for the turn's activity digest:
+	// true = this execution mattered (a real mutation, a failure worth
+	// remembering), false = don't bother (a no-op edit, a status read),
+	// nil = no opinion. The tool decides — consumers apply no heuristics.
+	Sticky *bool
 }
 
 // ToolContent is one model-facing block returned by a tool.

--- a/pkg/ctx/chat_context_part_provider.go
+++ b/pkg/ctx/chat_context_part_provider.go
@@ -9,10 +9,12 @@ import (
 	"github.com/kcaldas/genie/pkg/events"
 )
 
-// Message represents a user/assistant conversation pair
+// Message represents a user/assistant conversation pair, with the tool
+// activities that produced the assistant side.
 type Message struct {
-	User      string
-	Assistant string
+	User       string
+	Activities []events.ToolActivity
+	Assistant  string
 }
 
 // ChatContextPartProvider manages chat context for a single session
@@ -20,9 +22,10 @@ type ChatContextPartProvider interface {
 	ContextPartProvider
 	SeedHistory(history []Message)
 	SetBudgetStrategy(strategy CollectionBudgetStrategy[Message])
-	// AddTurn records one completed exchange. Empty user or assistant
-	// sides are allowed (ephemeral modes); a fully empty turn is ignored.
-	AddTurn(user, assistant string)
+	// AddTurn records one completed exchange, optionally with the tool
+	// activities that produced it. Empty user or assistant sides are
+	// allowed (ephemeral modes); a fully empty turn is ignored.
+	AddTurn(user, assistant string, activities ...events.ToolActivity)
 }
 
 // InMemoryChatContextPartProvider implements ChatCtxManager with in-memory storage
@@ -54,26 +57,17 @@ func NewChatCtxManager(eventBus events.EventBus) ChatContextPartProvider {
 }
 
 // AddTurn records one completed exchange in conversation history.
-func (p *InMemoryChatContextPartProvider) AddTurn(user, assistant string) {
+func (p *InMemoryChatContextPartProvider) AddTurn(user, assistant string, activities ...events.ToolActivity) {
 	if user == "" && assistant == "" {
 		return
 	}
-	p.addMessage(user, assistant)
-}
-
-func (p *InMemoryChatContextPartProvider) addMessage(user, assistant string) {
-	message := Message{}
-
-	if user != "" {
-		message.User = user
-	}
-
-	if assistant != "" {
-		message.Assistant = assistant
-	}
 
 	p.mu.Lock()
-	p.messages = append(p.messages, message)
+	p.messages = append(p.messages, Message{
+		User:       user,
+		Activities: activities,
+		Assistant:  assistant,
+	})
 	p.mu.Unlock()
 }
 
@@ -91,11 +85,28 @@ func (m *InMemoryChatContextPartProvider) SetTokenBudget(tokens int) {
 	m.tokenBudget = tokens
 }
 
-// formatMessage formats a single message for context output.
+// formatMessageForContext formats a single message for context output.
+// It is both the renderer and the budget-counting formatter, so
+// activities are counted in their turn's token cost by construction.
 func formatMessageForContext(msg Message) string {
 	var parts []string
 	if msg.User != "" {
 		parts = append(parts, "User: "+msg.User)
+	}
+	if len(msg.Activities) > 0 {
+		lines := make([]string, 0, len(msg.Activities)+1)
+		lines = append(lines, "Actions:")
+		for _, activity := range msg.Activities {
+			line := "- " + activity.Tool
+			if activity.Args != "" {
+				line += " " + activity.Args
+			}
+			if activity.Summary != "" {
+				line += " → " + activity.Summary
+			}
+			lines = append(lines, line)
+		}
+		parts = append(parts, strings.Join(lines, "\n"))
 	}
 	if msg.Assistant != "" {
 		parts = append(parts, "Assistant: "+msg.Assistant)
@@ -198,8 +209,9 @@ func (m *InMemoryChatContextPartProvider) SeedHistory(history []Message) {
 			continue
 		}
 		m.messages = append(m.messages, Message{
-			User:      msg.User,
-			Assistant: msg.Assistant,
+			User:       msg.User,
+			Activities: msg.Activities,
+			Assistant:  msg.Assistant,
 		})
 	}
 }

--- a/pkg/ctx/chat_context_part_provider.go
+++ b/pkg/ctx/chat_context_part_provider.go
@@ -95,7 +95,9 @@ func formatMessageForContext(msg Message) string {
 	}
 	if len(msg.Activities) > 0 {
 		lines := make([]string, 0, len(msg.Activities)+1)
-		lines = append(lines, "Actions:")
+		// "Assistant Actions" names the actor explicitly, matching the
+		// User:/Assistant: speaker labels around it.
+		lines = append(lines, "Assistant Actions:")
 		for _, activity := range msg.Activities {
 			line := "- " + activity.Tool
 			if activity.Args != "" {

--- a/pkg/ctx/chat_context_part_provider.go
+++ b/pkg/ctx/chat_context_part_provider.go
@@ -136,13 +136,12 @@ func (m *InMemoryChatContextPartProvider) GetPart(ctx context.Context) (ContextP
 		messages = kept
 	}
 
+	// Render with the same formatter the budget strategy counts with,
+	// so what the model sees is exactly what was budgeted.
 	var parts []string
 	for _, msg := range messages {
-		if msg.User != "" {
-			parts = append(parts, "User: "+msg.User)
-		}
-		if msg.Assistant != "" {
-			parts = append(parts, "Assistant: "+msg.Assistant)
+		if formatted := formatMessageForContext(msg); formatted != "" {
+			parts = append(parts, formatted)
 		}
 	}
 

--- a/pkg/ctx/chat_context_turns_test.go
+++ b/pkg/ctx/chat_context_turns_test.go
@@ -55,3 +55,51 @@ func TestChatProviderAddTurnSkipsEmptyTurns(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, part.Content)
 }
+
+// A turn's activities render as an Actions block between the user and
+// assistant sides, so the next turn sees what the previous one did.
+func TestChatCtxManager_RendersTurnActivities(t *testing.T) {
+	manager := NewChatCtxManager(events.NewEventBus())
+
+	manager.AddTurn("fix the tests", "Fixed and verified.",
+		events.ToolActivity{Tool: "bash", Args: `command="go test ./..."`, Success: false, Summary: "Failed: TestResponsesUsage"},
+		events.ToolActivity{Tool: "edit", Args: `file="turn.go"`, Success: true, Summary: "Executed"},
+	)
+
+	part, err := manager.GetPart(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, part.Content,
+		"User: fix the tests\n"+
+			"Actions:\n"+
+			"- bash command=\"go test ./...\" → Failed: TestResponsesUsage\n"+
+			"- edit file=\"turn.go\" → Executed\n"+
+			"Assistant: Fixed and verified.")
+}
+
+// Activities are part of the message, so the budget formatter must
+// include them: what the model sees is exactly what was counted.
+func TestFormatMessageForContextIncludesActivities(t *testing.T) {
+	formatted := formatMessageForContext(Message{
+		User:       "fix",
+		Activities: []events.ToolActivity{{Tool: "bash", Summary: "Executed"}},
+		Assistant:  "done",
+	})
+
+	assert.Contains(t, formatted, "Actions:\n- bash → Executed")
+}
+
+// Seeded history carries activities through unchanged, so a restored
+// turn renders identically to one recorded live.
+func TestChatCtxManager_SeedHistoryPreservesActivities(t *testing.T) {
+	manager := NewChatCtxManager(events.NewEventBus())
+
+	manager.SeedHistory([]Message{{
+		User:       "earlier request",
+		Activities: []events.ToolActivity{{Tool: "writeFile", Args: `path="a.go"`, Success: true, Summary: "Executed"}},
+		Assistant:  "earlier answer",
+	}})
+
+	part, err := manager.GetPart(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, part.Content, "Actions:\n- writeFile path=\"a.go\" → Executed")
+}

--- a/pkg/ctx/chat_context_turns_test.go
+++ b/pkg/ctx/chat_context_turns_test.go
@@ -70,7 +70,7 @@ func TestChatCtxManager_RendersTurnActivities(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, part.Content,
 		"User: fix the tests\n"+
-			"Actions:\n"+
+			"Assistant Actions:\n"+
 			"- bash command=\"go test ./...\" → Failed: TestResponsesUsage\n"+
 			"- edit file=\"turn.go\" → Executed\n"+
 			"Assistant: Fixed and verified.")
@@ -85,7 +85,7 @@ func TestFormatMessageForContextIncludesActivities(t *testing.T) {
 		Assistant:  "done",
 	})
 
-	assert.Contains(t, formatted, "Actions:\n- bash → Executed")
+	assert.Contains(t, formatted, "Assistant Actions:\n- bash → Executed")
 }
 
 // Seeded history carries activities through unchanged, so a restored
@@ -101,5 +101,5 @@ func TestChatCtxManager_SeedHistoryPreservesActivities(t *testing.T) {
 
 	part, err := manager.GetPart(context.Background())
 	require.NoError(t, err)
-	assert.Contains(t, part.Content, "Actions:\n- writeFile path=\"a.go\" → Executed")
+	assert.Contains(t, part.Content, "Assistant Actions:\n- writeFile path=\"a.go\" → Executed")
 }

--- a/pkg/ctx/context_manager.go
+++ b/pkg/ctx/context_manager.go
@@ -2,6 +2,8 @@ package ctx
 
 import (
 	"context"
+
+	"github.com/kcaldas/genie/pkg/events"
 )
 
 // ContextPart represents a part of the context with its key
@@ -51,9 +53,10 @@ type ContextManager interface {
 	ClearContext() error
 	SeedChatHistory(history []Message)
 	// RecordChatTurn synchronously appends a completed exchange to the
-	// conversation history. The core calls this after each successful
-	// turn; history must never depend on asynchronous event delivery.
-	RecordChatTurn(user, assistant string)
+	// conversation history, optionally with the tool activities that
+	// produced it. The core calls this after each successful turn;
+	// history must never depend on asynchronous event delivery.
+	RecordChatTurn(user, assistant string, activities ...events.ToolActivity)
 	SetContextBudget(totalTokens int)
 }
 
@@ -128,10 +131,12 @@ func (m *InMemoryManager) SeedChatHistory(history []Message) {
 }
 
 // RecordChatTurn appends a completed exchange to the chat history provider.
-func (m *InMemoryManager) RecordChatTurn(user, assistant string) {
+func (m *InMemoryManager) RecordChatTurn(user, assistant string, activities ...events.ToolActivity) {
 	for _, provider := range m.registry.GetProviders() {
-		if recorder, ok := provider.(interface{ AddTurn(string, string) }); ok {
-			recorder.AddTurn(user, assistant)
+		if recorder, ok := provider.(interface {
+			AddTurn(string, string, ...events.ToolActivity)
+		}); ok {
+			recorder.AddTurn(user, assistant, activities...)
 			return
 		}
 	}

--- a/pkg/events/session_events.go
+++ b/pkg/events/session_events.go
@@ -106,9 +106,13 @@ type ChatResponseEvent struct {
 	RequestID string
 	Message   string
 	Response  string
-	Error     error
-	UserInput string
-	Ephemeral int // 0=store both, 1=skip input, 2=skip output, 3=skip both
+	// Activities is the turn's bounded tool digest, for hosts to persist
+	// alongside the assistant message. Present on failed turns too — they
+	// still ran tools.
+	Activities []ToolActivity
+	Error      error
+	UserInput  string
+	Ephemeral  int // 0=store both, 1=skip input, 2=skip output, 3=skip both
 }
 
 // Topic returns the event topic for chat responses

--- a/pkg/events/session_events.go
+++ b/pkg/events/session_events.go
@@ -42,6 +42,9 @@ type ToolExecutedEvent struct {
 	Success    bool           // Whether the tool handler returned without error
 	Message    string         // Human-readable outcome for display
 	Result     map[string]any // The actual result returned by the tool
+	// Sticky is the tool's retention hint, copied verbatim from its
+	// ToolOutput: nil when the tool expressed no opinion.
+	Sticky *bool
 }
 
 // Topic returns the event topic for tool execution

--- a/pkg/events/session_events.go
+++ b/pkg/events/session_events.go
@@ -4,6 +4,18 @@ import (
 	"github.com/kcaldas/genie/pkg/ai"
 )
 
+// ToolActivity is a bounded record of one tool execution: what ran, with
+// what arguments, and how it went. Core builds it once per tool call —
+// truncated at creation, never carrying result bodies — and pairs it with
+// the turn in chat context and on the chat response event.
+type ToolActivity struct {
+	Tool    string
+	Args    string // bounded one-liner, truncated at creation
+	Success bool
+	Summary string // bounded outcome, truncated at creation
+	Sticky  bool   // tool-declared: survives longer in context
+}
+
 // ToolStartingEvent represents a tool that is about to be executed
 type ToolStartingEvent struct {
 	ExecutionID string

--- a/pkg/events/session_events.go
+++ b/pkg/events/session_events.go
@@ -7,8 +7,11 @@ import (
 // ToolStartingEvent represents a tool that is about to be executed
 type ToolStartingEvent struct {
 	ExecutionID string
-	ToolName    string
-	Parameters  map[string]any
+	// RequestID ties the tool call to the chat request that caused it.
+	// Empty when the tool runs outside a chat turn.
+	RequestID  string
+	ToolName   string
+	Parameters map[string]any
 }
 
 // Topic returns the event topic for tool starting
@@ -19,11 +22,14 @@ func (e ToolStartingEvent) Topic() string {
 // ToolExecutedEvent represents a tool that has been executed
 type ToolExecutedEvent struct {
 	ExecutionID string
-	ToolName    string
-	Parameters  map[string]any
-	Success     bool           // Whether the tool handler returned without error
-	Message     string         // Human-readable outcome for display
-	Result      map[string]any // The actual result returned by the tool
+	// RequestID ties the tool call to the chat request that caused it.
+	// Empty when the tool runs outside a chat turn.
+	RequestID  string
+	ToolName   string
+	Parameters map[string]any
+	Success    bool           // Whether the tool handler returned without error
+	Message    string         // Human-readable outcome for display
+	Result     map[string]any // The actual result returned by the tool
 }
 
 // Topic returns the event topic for tool execution

--- a/pkg/genie/chat_activities_test.go
+++ b/pkg/genie/chat_activities_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kcaldas/genie/pkg/genie"
 	"github.com/kcaldas/genie/pkg/genie/genietest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,4 +68,53 @@ func TestChatWithoutToolsHasNoActivities(t *testing.T) {
 	response := fixture.WaitForResponseOrFail(2 * time.Second)
 
 	assert.Empty(t, response.Activities)
+}
+
+// The next turn's prompt context carries the previous turn's Actions
+// block: the model is no longer procedurally blind between turns.
+func TestNextTurnSeesPreviousActivities(t *testing.T) {
+	fixture := genietest.NewTestFixture(t)
+	defer fixture.Cleanup()
+	fixture.StartAndGetSession()
+
+	fixture.ExpectMessage("fix it").
+		MockTool("bash").Returns(map[string]any{"exit": 1}).
+		RespondWith("fixed")
+	fixture.ExpectSimpleMessage("thanks", "welcome")
+
+	require.NoError(t, fixture.StartChat("fix it"))
+	fixture.WaitForResponseOrFail(2 * time.Second)
+
+	require.NoError(t, fixture.StartChat("thanks"))
+	fixture.WaitForResponseOrFail(2 * time.Second)
+
+	captured := fixture.MockPromptRunner.CapturedData()
+	require.Len(t, captured, 2)
+	chat := captured[1]["chat"]
+	assert.Contains(t, chat, "User: fix it")
+	assert.Contains(t, chat, "Actions:\n- bash → Executed (mocked)")
+	assert.Contains(t, chat, "Assistant: fixed")
+}
+
+// Ephemeral turns must not leak tool activity into history: activity
+// args can carry the very content the ephemeral mode is hiding.
+func TestEphemeralTurnRecordsNoActivities(t *testing.T) {
+	fixture := genietest.NewTestFixture(t)
+	defer fixture.Cleanup()
+	fixture.StartAndGetSession()
+
+	fixture.ExpectMessage("secret request").
+		MockTool("bash").Returns(map[string]any{"exit": 0}).
+		RespondWith("done quietly")
+	fixture.ExpectSimpleMessage("next", "ok")
+
+	require.NoError(t, fixture.StartChat("secret request", genie.WithEphemeral(genie.EphemeralInput)))
+	fixture.WaitForResponseOrFail(2 * time.Second)
+
+	require.NoError(t, fixture.StartChat("next"))
+	fixture.WaitForResponseOrFail(2 * time.Second)
+
+	captured := fixture.MockPromptRunner.CapturedData()
+	require.Len(t, captured, 2)
+	assert.NotContains(t, captured[1]["chat"], "Actions:")
 }

--- a/pkg/genie/chat_activities_test.go
+++ b/pkg/genie/chat_activities_test.go
@@ -92,7 +92,7 @@ func TestNextTurnSeesPreviousActivities(t *testing.T) {
 	require.Len(t, captured, 2)
 	chat := captured[1]["chat"]
 	assert.Contains(t, chat, "User: fix it")
-	assert.Contains(t, chat, "Actions:\n- bash → Executed (mocked)")
+	assert.Contains(t, chat, "Assistant Actions:\n- bash → Executed (mocked)")
 	assert.Contains(t, chat, "Assistant: fixed")
 }
 
@@ -116,5 +116,5 @@ func TestEphemeralTurnRecordsNoActivities(t *testing.T) {
 
 	captured := fixture.MockPromptRunner.CapturedData()
 	require.Len(t, captured, 2)
-	assert.NotContains(t, captured[1]["chat"], "Actions:")
+	assert.NotContains(t, captured[1]["chat"], "Assistant Actions:")
 }

--- a/pkg/genie/chat_activities_test.go
+++ b/pkg/genie/chat_activities_test.go
@@ -1,0 +1,70 @@
+package genie_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kcaldas/genie/pkg/genie/genietest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The chat response event carries the turn's tool activity digest so
+// hosts can persist it alongside the assistant message.
+func TestChatResponseCarriesToolActivities(t *testing.T) {
+	fixture := genietest.NewTestFixture(t)
+	defer fixture.Cleanup()
+	fixture.StartAndGetSession()
+
+	fixture.ExpectMessage("fix the tests").
+		MockTool("searchInFiles").Returns(map[string]any{"matches": 8}).
+		MockTool("bash").Returns(map[string]any{"exit": 0}).
+		RespondWith("done")
+
+	require.NoError(t, fixture.StartChat("fix the tests"))
+	response := fixture.WaitForResponseOrFail(2 * time.Second)
+
+	require.Len(t, response.Activities, 2)
+	assert.Equal(t, "searchInFiles", response.Activities[0].Tool)
+	assert.Equal(t, "bash", response.Activities[1].Tool)
+	assert.True(t, response.Activities[0].Success)
+	assert.NotEmpty(t, response.Activities[0].Summary)
+}
+
+// Draining at turn end must remove the request's bucket: a later turn
+// carries only its own activities.
+func TestChatActivitiesDoNotLeakAcrossTurns(t *testing.T) {
+	fixture := genietest.NewTestFixture(t)
+	defer fixture.Cleanup()
+	fixture.StartAndGetSession()
+
+	fixture.ExpectMessage("first").
+		MockTool("bash").Returns(map[string]any{"exit": 0}).
+		RespondWith("one")
+	fixture.ExpectMessage("second").
+		MockTool("readFile").Returns(map[string]any{"results": "x"}).
+		RespondWith("two")
+
+	require.NoError(t, fixture.StartChat("first"))
+	first := fixture.WaitForResponseOrFail(2 * time.Second)
+	require.Len(t, first.Activities, 1)
+
+	require.NoError(t, fixture.StartChat("second"))
+	second := fixture.WaitForResponseOrFail(2 * time.Second)
+	require.Len(t, second.Activities, 1)
+	assert.Equal(t, "readFile", second.Activities[0].Tool)
+}
+
+// A turn with no tool calls carries no activities.
+func TestChatWithoutToolsHasNoActivities(t *testing.T) {
+	fixture := genietest.NewTestFixture(t)
+	defer fixture.Cleanup()
+	fixture.StartAndGetSession()
+
+	fixture.ExpectSimpleMessage("hello", "hi")
+
+	require.NoError(t, fixture.StartChat("hello"))
+	response := fixture.WaitForResponseOrFail(2 * time.Second)
+
+	assert.Empty(t, response.Activities)
+}

--- a/pkg/genie/core.go
+++ b/pkg/genie/core.go
@@ -468,7 +468,7 @@ func (g *core) Chat(ctx context.Context, message string, opts ...ChatOption) err
 		// not recorded — a partial answer would corrupt every later
 		// turn's view of the conversation.
 		if err == nil {
-			g.recordChatTurn(message, response, options.ephemeral)
+			g.recordChatTurn(message, response, options.ephemeral, activities)
 		}
 
 		// Session recording: the turn's tool entries were already
@@ -809,7 +809,7 @@ func redactionFor(mode EphemeralMode) session.Redaction {
 
 // recordChatTurn applies the turn's ephemeral mode and appends what
 // remains to conversation history.
-func (g *core) recordChatTurn(userMsg, assistantMsg string, mode EphemeralMode) {
+func (g *core) recordChatTurn(userMsg, assistantMsg string, mode EphemeralMode, activities []events.ToolActivity) {
 	switch mode {
 	case EphemeralInput:
 		userMsg = ""
@@ -821,7 +821,12 @@ func (g *core) recordChatTurn(userMsg, assistantMsg string, mode EphemeralMode) 
 	if userMsg == "" && assistantMsg == "" {
 		return
 	}
-	g.contextMgr.RecordChatTurn(userMsg, assistantMsg)
+	// Any ephemeral mode drops the turn's activities: activity args can
+	// carry the very content the mode is hiding.
+	if mode != EphemeralNone {
+		activities = nil
+	}
+	g.contextMgr.RecordChatTurn(userMsg, assistantMsg, activities...)
 }
 
 // buildSystemContext lifts auto-loaded context parts (files, project,

--- a/pkg/genie/core.go
+++ b/pkg/genie/core.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/kcaldas/genie/pkg/ai"
@@ -113,6 +114,11 @@ type core struct {
 	recorder        *session.Recorder
 	started         bool
 	missingTools    []string
+
+	// activities accumulates each in-flight request's tool digest,
+	// keyed by request ID and drained at turn end.
+	activityMu sync.Mutex
+	activities map[string]*activityLog
 }
 
 // newGenieCore creates a new Genie core instance with dependency injection
@@ -138,7 +144,9 @@ func newGenieCore(
 		configMgr:       configMgr,
 		toolRegistry:    toolRegistry,
 		recorder:        recorder,
+		activities:      make(map[string]*activityLog),
 	}
+	g.subscribeActivityCollector()
 	if recorder != nil {
 		g.subscribeRecorderEvents()
 	}
@@ -436,16 +444,22 @@ func (g *core) Chat(ctx context.Context, message string, opts ...ChatOption) err
 			if r := recover(); r != nil {
 				panicErr := fmt.Errorf("internal error: %v", r)
 				responseEvent := events.ChatResponseEvent{
-					RequestID: options.requestID,
-					Message:   message,
-					Response:  "",
-					Error:     panicErr,
+					RequestID:  options.requestID,
+					Message:    message,
+					Response:   "",
+					Activities: g.takeActivities(options.requestID),
+					Error:      panicErr,
 				}
 				g.eventBus.Publish(responseEvent.Topic(), responseEvent)
 			}
 		}()
 
 		response, err := g.processChat(ctx, message, options)
+
+		// The turn's tool digest: complete by now — tool events are
+		// published synchronously by the prompt loop. Drained exactly
+		// once so buckets never leak.
+		activities := g.takeActivities(options.requestID)
 
 		// Record the completed turn in conversation history BEFORE
 		// publishing the response event: history is correctness state
@@ -473,11 +487,12 @@ func (g *core) Chat(ctx context.Context, message string, opts ...ChatOption) err
 		// Publish response event (success or error) for observers
 		// (TUI rendering, CLI output). Purely notification.
 		responseEvent := events.ChatResponseEvent{
-			RequestID: options.requestID,
-			Message:   message,
-			Response:  response,
-			Error:     err,
-			Ephemeral: int(options.ephemeral),
+			RequestID:  options.requestID,
+			Message:    message,
+			Response:   response,
+			Activities: activities,
+			Error:      err,
+			Ephemeral:  int(options.ephemeral),
 		}
 		g.eventBus.Publish(responseEvent.Topic(), responseEvent)
 	}(chatOpts)

--- a/pkg/genie/core_chat_test.go
+++ b/pkg/genie/core_chat_test.go
@@ -218,3 +218,26 @@ func TestStartWithChatHistorySeedsChatContext(t *testing.T) {
 	assert.Contains(t, contextMap["chat"], "User: Earlier question")
 	assert.Contains(t, contextMap["chat"], "Assistant: Earlier answer")
 }
+
+// Seeded turns carry their activity digest (e.g. restored by a host
+// from persisted messages), rendering identically to live turns.
+func TestStartWithChatHistorySeedsActivities(t *testing.T) {
+	fixture := genietest.NewTestFixture(t)
+	defer fixture.Cleanup()
+
+	fixture.StartAndGetSession(genie.WithChatHistory(genie.ChatHistoryTurn{
+		User: "Earlier request",
+		Activities: []events.ToolActivity{
+			{Tool: "bash", Args: `command="go test"`, Success: false, Summary: "Failed: TestX"},
+		},
+		Assistant: "Earlier answer",
+	}))
+
+	contextMap, err := fixture.Genie.GetContext(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, contextMap["chat"],
+		"User: Earlier request\n"+
+			"Actions:\n"+
+			"- bash command=\"go test\" → Failed: TestX\n"+
+			"Assistant: Earlier answer")
+}

--- a/pkg/genie/core_chat_test.go
+++ b/pkg/genie/core_chat_test.go
@@ -237,7 +237,7 @@ func TestStartWithChatHistorySeedsActivities(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, contextMap["chat"],
 		"User: Earlier request\n"+
-			"Actions:\n"+
+			"Assistant Actions:\n"+
 			"- bash command=\"go test\" → Failed: TestX\n"+
 			"Assistant: Earlier answer")
 }

--- a/pkg/genie/core_test.go
+++ b/pkg/genie/core_test.go
@@ -29,7 +29,7 @@ func (m *MockContextManager) SeedChatHistory(history []ctx.Message) {
 	m.Called(history)
 }
 
-func (m *MockContextManager) RecordChatTurn(user, assistant string) {
+func (m *MockContextManager) RecordChatTurn(user, assistant string, activities ...events.ToolActivity) {
 	m.Called(user, assistant)
 }
 

--- a/pkg/genie/genietest/fixture.go
+++ b/pkg/genie/genietest/fixture.go
@@ -257,8 +257,8 @@ func (f *TestFixture) StartAndGetSession(opts ...genie.StartOption) genie.Sessio
 }
 
 // StartChat initiates a chat and returns immediately (async operation)
-func (f *TestFixture) StartChat(message string) error {
-	return f.Genie.Chat(context.Background(), message)
+func (f *TestFixture) StartChat(message string, opts ...genie.ChatOption) error {
+	return f.Genie.Chat(context.Background(), message, opts...)
 }
 
 // WaitForResponse waits for a chat response event with timeout

--- a/pkg/genie/genietest/mock_prompt_runner.go
+++ b/pkg/genie/genietest/mock_prompt_runner.go
@@ -211,6 +211,7 @@ func (r *MockPromptRunner) executeMockToolCall(ctx context.Context, data interfa
 	if r.eventBus != nil {
 		startEvent := events.ToolStartingEvent{
 			ExecutionID: executionID,
+			RequestID:   genie.RequestIDFromContext(ctx),
 			ToolName:    toolCall.ToolName,
 			Parameters:  map[string]any{},
 		}
@@ -224,6 +225,7 @@ func (r *MockPromptRunner) executeMockToolCall(ctx context.Context, data interfa
 	if r.eventBus != nil {
 		event := events.ToolExecutedEvent{
 			ExecutionID: executionID,
+			RequestID:   genie.RequestIDFromContext(ctx),
 			ToolName:    toolCall.ToolName,
 			Parameters:  map[string]any{}, // Mock tools don't need real parameters
 			Success:     true,

--- a/pkg/genie/start_options.go
+++ b/pkg/genie/start_options.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/kcaldas/genie/pkg/ctx"
+	"github.com/kcaldas/genie/pkg/events"
 )
 
 type StartOption func(*startOptions)
@@ -18,10 +19,13 @@ type startOptions struct {
 	commitAuthorEmail string
 }
 
-// ChatHistoryTurn represents a prior exchange between user and assistant.
+// ChatHistoryTurn represents a prior exchange between user and assistant,
+// optionally with the tool activities that produced the assistant side —
+// hosts restore them from wherever they persisted the turn's digest.
 type ChatHistoryTurn struct {
-	User      string
-	Assistant string
+	User       string
+	Activities []events.ToolActivity
+	Assistant  string
 }
 
 // WithChatHistory seeds Genie with prior chat history so prompts include it from the start.
@@ -33,8 +37,9 @@ func WithChatHistory(turns ...ChatHistoryTurn) StartOption {
 				continue
 			}
 			opts.chatHistory = append(opts.chatHistory, ChatHistoryTurn{
-				User:      turn.User,
-				Assistant: turn.Assistant,
+				User:       turn.User,
+				Activities: turn.Activities,
+				Assistant:  turn.Assistant,
 			})
 		}
 	}
@@ -119,8 +124,9 @@ func (s startOptions) toMessages() []ctx.Message {
 			continue
 		}
 		messages = append(messages, ctx.Message{
-			User:      turn.User,
-			Assistant: turn.Assistant,
+			User:       turn.User,
+			Activities: turn.Activities,
+			Assistant:  turn.Assistant,
 		})
 	}
 	if len(messages) == 0 {

--- a/pkg/genie/tool_activity.go
+++ b/pkg/genie/tool_activity.go
@@ -1,0 +1,118 @@
+package genie
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/kcaldas/genie/pkg/events"
+)
+
+// Bounds applied when converting tool events into activities. These are
+// safety caps, not policy: they keep every digest small no matter what a
+// tool produced. What matters (Sticky) is declared by tools, never here.
+const (
+	maxActivityFieldBytes   = 160
+	maxActivitiesPerRequest = 50
+)
+
+// toActivity converts a tool event into its bounded activity record. This
+// is the only door: truncation happens here and nowhere else.
+func toActivity(event events.ToolExecutedEvent) events.ToolActivity {
+	return events.ToolActivity{
+		Tool:    event.ToolName,
+		Args:    truncateActivityField(formatActivityArgs(event.Parameters)),
+		Success: event.Success,
+		Summary: truncateActivityField(event.Message),
+	}
+}
+
+// formatActivityArgs renders parameters as a deterministic one-liner:
+// `key="value"` pairs in sorted key order.
+func formatActivityArgs(params map[string]any) string {
+	if len(params) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]string, 0, len(keys))
+	for _, key := range keys {
+		switch value := params[key].(type) {
+		case string:
+			pairs = append(pairs, fmt.Sprintf("%s=%q", key, value))
+		default:
+			pairs = append(pairs, fmt.Sprintf("%s=%v", key, value))
+		}
+	}
+	return strings.Join(pairs, " ")
+}
+
+// truncateActivityField caps a field at maxActivityFieldBytes with an
+// explicit marker, cutting at a rune boundary.
+func truncateActivityField(text string) string {
+	if len(text) <= maxActivityFieldBytes {
+		return text
+	}
+	marker := "…"
+	cut := maxActivityFieldBytes - len(marker)
+	for cut > 0 && !isRuneStart(text[cut]) {
+		cut--
+	}
+	return text[:cut] + marker
+}
+
+func isRuneStart(b byte) bool {
+	return b&0xC0 != 0x80
+}
+
+// activityLog accumulates one request's activities under a cap that drops
+// the middle: the first and last calls of a long turn carry the most
+// signal (what it set out to do, how it ended).
+type activityLog struct {
+	head    []events.ToolActivity
+	tail    []events.ToolActivity // ring once full
+	tailPos int
+	dropped int
+}
+
+func newActivityLog() *activityLog {
+	return &activityLog{}
+}
+
+func (l *activityLog) add(activity events.ToolActivity) {
+	headCap := maxActivitiesPerRequest / 2
+	tailCap := maxActivitiesPerRequest - headCap
+
+	if len(l.head) < headCap {
+		l.head = append(l.head, activity)
+		return
+	}
+	if len(l.tail) < tailCap {
+		l.tail = append(l.tail, activity)
+		return
+	}
+	l.tail[l.tailPos] = activity
+	l.tailPos = (l.tailPos + 1) % tailCap
+	l.dropped++
+}
+
+// drain returns the accumulated activities in order, with an omission
+// marker in place of any dropped middle section.
+func (l *activityLog) drain() []events.ToolActivity {
+	activities := make([]events.ToolActivity, 0, len(l.head)+len(l.tail)+1)
+	activities = append(activities, l.head...)
+	if l.dropped > 0 {
+		activities = append(activities, events.ToolActivity{
+			Tool:    "…",
+			Success: true,
+			Summary: fmt.Sprintf("%d more actions omitted", l.dropped),
+		})
+	}
+	activities = append(activities, l.tail[l.tailPos:]...)
+	activities = append(activities, l.tail[:l.tailPos]...)
+	return activities
+}

--- a/pkg/genie/tool_activity.go
+++ b/pkg/genie/tool_activity.go
@@ -69,6 +69,41 @@ func isRuneStart(b byte) bool {
 	return b&0xC0 != 0x80
 }
 
+// subscribeActivityCollector accumulates each chat request's tool digest
+// from the synchronously published tool events, so it is complete by the
+// time processChat returns. Events without a request ID (tools run
+// outside a chat turn) are not collected.
+func (g *core) subscribeActivityCollector() {
+	g.eventBus.Subscribe(events.ToolExecutedEvent{}.Topic(), func(event any) {
+		e, ok := event.(events.ToolExecutedEvent)
+		if !ok || e.RequestID == "" {
+			return
+		}
+		g.activityMu.Lock()
+		defer g.activityMu.Unlock()
+		log, found := g.activities[e.RequestID]
+		if !found {
+			log = newActivityLog()
+			g.activities[e.RequestID] = log
+		}
+		log.add(toActivity(e))
+	})
+}
+
+// takeActivities removes and returns a request's accumulated digest.
+// Called exactly once per request at turn end (including the panic
+// path), so buckets never leak.
+func (g *core) takeActivities(requestID string) []events.ToolActivity {
+	g.activityMu.Lock()
+	defer g.activityMu.Unlock()
+	log, found := g.activities[requestID]
+	if !found {
+		return nil
+	}
+	delete(g.activities, requestID)
+	return log.drain()
+}
+
 // activityLog accumulates one request's activities under a cap that drops
 // the middle: the first and last calls of a long turn carry the most
 // signal (what it set out to do, how it ended).

--- a/pkg/genie/tool_activity.go
+++ b/pkg/genie/tool_activity.go
@@ -24,6 +24,9 @@ func toActivity(event events.ToolExecutedEvent) events.ToolActivity {
 		Args:    truncateActivityField(formatActivityArgs(event.Parameters)),
 		Success: event.Success,
 		Summary: truncateActivityField(event.Message),
+		// Sticky iff the tool said so — nil (no opinion) resolves to
+		// false, and core applies no heuristics of its own.
+		Sticky: event.Sticky != nil && *event.Sticky,
 	}
 }
 

--- a/pkg/genie/tool_activity.go
+++ b/pkg/genie/tool_activity.go
@@ -107,14 +107,11 @@ func (g *core) takeActivities(requestID string) []events.ToolActivity {
 	return log.drain()
 }
 
-// activityLog accumulates one request's activities under a cap that drops
-// the middle: the first and last calls of a long turn carry the most
-// signal (what it set out to do, how it ended).
+// activityLog accumulates one request's activities. Entries are bounded
+// individually at creation; the collection is capped at drain time,
+// where the full turn is known and sticky entries can be honored.
 type activityLog struct {
-	head    []events.ToolActivity
-	tail    []events.ToolActivity // ring once full
-	tailPos int
-	dropped int
+	entries []events.ToolActivity
 }
 
 func newActivityLog() *activityLog {
@@ -122,35 +119,73 @@ func newActivityLog() *activityLog {
 }
 
 func (l *activityLog) add(activity events.ToolActivity) {
-	headCap := maxActivitiesPerRequest / 2
-	tailCap := maxActivitiesPerRequest - headCap
-
-	if len(l.head) < headCap {
-		l.head = append(l.head, activity)
-		return
-	}
-	if len(l.tail) < tailCap {
-		l.tail = append(l.tail, activity)
-		return
-	}
-	l.tail[l.tailPos] = activity
-	l.tailPos = (l.tailPos + 1) % tailCap
-	l.dropped++
+	l.entries = append(l.entries, activity)
 }
 
-// drain returns the accumulated activities in order, with an omission
-// marker in place of any dropped middle section.
+// drain returns the turn's activities in execution order, capped at
+// maxActivitiesPerRequest with omission markers in place of dropped
+// runs. Selection under the cap:
+//
+//   - Sticky entries survive wherever they fall — the tool said keep
+//     this, and the cap must not overrule it (newest preferred if
+//     sticky alone exceeds the cap).
+//   - The remaining budget drops the middle, biased toward the tail
+//     (1/3 head, 2/3 tail): the head shows what the turn set out to
+//     do; the final calls are where the model, after exploring,
+//     actually acts.
 func (l *activityLog) drain() []events.ToolActivity {
-	activities := make([]events.ToolActivity, 0, len(l.head)+len(l.tail)+1)
-	activities = append(activities, l.head...)
-	if l.dropped > 0 {
-		activities = append(activities, events.ToolActivity{
-			Tool:    "…",
-			Success: true,
-			Summary: fmt.Sprintf("%d more actions omitted", l.dropped),
-		})
+	if len(l.entries) <= maxActivitiesPerRequest {
+		return l.entries
 	}
-	activities = append(activities, l.tail[l.tailPos:]...)
-	activities = append(activities, l.tail[:l.tailPos]...)
+
+	keep := make([]bool, len(l.entries))
+	budget := maxActivitiesPerRequest
+
+	for i := len(l.entries) - 1; i >= 0 && budget > 0; i-- {
+		if l.entries[i].Sticky {
+			keep[i] = true
+			budget--
+		}
+	}
+
+	headShare := budget / 3
+	tailShare := budget - headShare
+	for i := len(l.entries) - 1; i >= 0 && tailShare > 0; i-- {
+		if !keep[i] {
+			keep[i] = true
+			tailShare--
+		}
+	}
+	for i := 0; i < len(l.entries) && headShare > 0; i++ {
+		if !keep[i] {
+			keep[i] = true
+			headShare--
+		}
+	}
+
+	activities := make([]events.ToolActivity, 0, maxActivitiesPerRequest+2)
+	dropped := 0
+	for i, entry := range l.entries {
+		if !keep[i] {
+			dropped++
+			continue
+		}
+		if dropped > 0 {
+			activities = append(activities, omissionMarker(dropped))
+			dropped = 0
+		}
+		activities = append(activities, entry)
+	}
+	if dropped > 0 {
+		activities = append(activities, omissionMarker(dropped))
+	}
 	return activities
+}
+
+func omissionMarker(count int) events.ToolActivity {
+	return events.ToolActivity{
+		Tool:    "…",
+		Success: true,
+		Summary: fmt.Sprintf("%d more actions omitted", count),
+	}
 }

--- a/pkg/genie/tool_activity_test.go
+++ b/pkg/genie/tool_activity_test.go
@@ -1,0 +1,93 @@
+package genie
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kcaldas/genie/pkg/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToActivityCopiesOutcome(t *testing.T) {
+	event := events.ToolExecutedEvent{
+		ToolName:   "bash",
+		Parameters: map[string]any{"command": "go test ./..."},
+		Success:    false,
+		Message:    "Failed: TestResponsesUsage",
+	}
+
+	activity := toActivity(event)
+
+	assert.Equal(t, "bash", activity.Tool)
+	assert.Equal(t, `command="go test ./..."`, activity.Args)
+	assert.False(t, activity.Success)
+	assert.Equal(t, "Failed: TestResponsesUsage", activity.Summary)
+	assert.False(t, activity.Sticky)
+}
+
+func TestToActivityFormatsArgsInSortedKeyOrder(t *testing.T) {
+	event := events.ToolExecutedEvent{
+		ToolName:   "searchInFiles",
+		Parameters: map[string]any{"scope": "pkg/llm", "query": "publishUsage", "max": 8},
+		Success:    true,
+		Message:    "Executed",
+	}
+
+	activity := toActivity(event)
+
+	assert.Equal(t, `max=8 query="publishUsage" scope="pkg/llm"`, activity.Args)
+}
+
+func TestToActivityTruncatesLongFields(t *testing.T) {
+	longValue := strings.Repeat("x", 4000)
+	event := events.ToolExecutedEvent{
+		ToolName:   "writeFile",
+		Parameters: map[string]any{"content": longValue},
+		Success:    true,
+		Message:    strings.Repeat("y", 4000),
+	}
+
+	activity := toActivity(event)
+
+	assert.LessOrEqual(t, len(activity.Args), maxActivityFieldBytes)
+	assert.LessOrEqual(t, len(activity.Summary), maxActivityFieldBytes)
+	assert.True(t, strings.HasSuffix(activity.Args, "…"), "truncation must be explicit")
+	assert.True(t, strings.HasSuffix(activity.Summary, "…"), "truncation must be explicit")
+}
+
+func TestActivityLogPreservesOrderBelowCap(t *testing.T) {
+	log := newActivityLog()
+	for i := range 3 {
+		log.add(events.ToolActivity{Tool: fmt.Sprintf("tool-%d", i)})
+	}
+
+	activities := log.drain()
+
+	require.Len(t, activities, 3)
+	for i, activity := range activities {
+		assert.Equal(t, fmt.Sprintf("tool-%d", i), activity.Tool)
+	}
+}
+
+func TestActivityLogDropsTheMiddleAtCap(t *testing.T) {
+	log := newActivityLog()
+	total := maxActivitiesPerRequest + 10
+	for i := range total {
+		log.add(events.ToolActivity{Tool: fmt.Sprintf("tool-%d", i)})
+	}
+
+	activities := log.drain()
+
+	require.Len(t, activities, maxActivitiesPerRequest+1, "capped entries plus one omission marker")
+
+	head := maxActivitiesPerRequest / 2
+	assert.Equal(t, "tool-0", activities[0].Tool)
+	assert.Equal(t, fmt.Sprintf("tool-%d", head-1), activities[head-1].Tool)
+
+	marker := activities[head]
+	assert.Contains(t, marker.Summary, "10 more actions")
+
+	assert.Equal(t, fmt.Sprintf("tool-%d", total-1), activities[len(activities)-1].Tool)
+}

--- a/pkg/genie/tool_activity_test.go
+++ b/pkg/genie/tool_activity_test.go
@@ -27,6 +27,29 @@ func TestToActivityCopiesOutcome(t *testing.T) {
 	assert.False(t, activity.Sticky)
 }
 
+// Sticky is resolved from the tool's explicit hint alone: set → believed,
+// nil → false. No heuristics in core.
+func TestToActivityResolvesStickyFromToolHint(t *testing.T) {
+	sticky := true
+	notSticky := false
+	tests := []struct {
+		name string
+		hint *bool
+		want bool
+	}{
+		{name: "tool says keep", hint: &sticky, want: true},
+		{name: "tool says don't bother", hint: &notSticky, want: false},
+		{name: "no opinion defaults to false", hint: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			activity := toActivity(events.ToolExecutedEvent{ToolName: "edit", Sticky: tt.hint})
+			assert.Equal(t, tt.want, activity.Sticky)
+		})
+	}
+}
+
 func TestToActivityFormatsArgsInSortedKeyOrder(t *testing.T) {
 	event := events.ToolExecutedEvent{
 		ToolName:   "searchInFiles",

--- a/pkg/genie/tool_activity_test.go
+++ b/pkg/genie/tool_activity_test.go
@@ -94,6 +94,9 @@ func TestActivityLogPreservesOrderBelowCap(t *testing.T) {
 	}
 }
 
+// Capping drops the middle, biased toward the tail: the head only needs
+// to show what the turn set out to do, while the final calls are where
+// the model, after exploring, actually acts.
 func TestActivityLogDropsTheMiddleAtCap(t *testing.T) {
 	log := newActivityLog()
 	total := maxActivitiesPerRequest + 10
@@ -105,12 +108,55 @@ func TestActivityLogDropsTheMiddleAtCap(t *testing.T) {
 
 	require.Len(t, activities, maxActivitiesPerRequest+1, "capped entries plus one omission marker")
 
-	head := maxActivitiesPerRequest / 2
+	head := maxActivitiesPerRequest / 3
 	assert.Equal(t, "tool-0", activities[0].Tool)
 	assert.Equal(t, fmt.Sprintf("tool-%d", head-1), activities[head-1].Tool)
 
 	marker := activities[head]
 	assert.Contains(t, marker.Summary, "10 more actions")
 
+	firstTail := total - (maxActivitiesPerRequest - head)
+	assert.Equal(t, fmt.Sprintf("tool-%d", firstTail), activities[head+1].Tool,
+		"the entry after the marker is the first kept tail entry")
 	assert.Equal(t, fmt.Sprintf("tool-%d", total-1), activities[len(activities)-1].Tool)
+}
+
+// Sticky entries survive capping wherever they fall: the tool said keep
+// this, and the cap must not overrule it.
+func TestActivityLogKeepsStickyWhenCapping(t *testing.T) {
+	log := newActivityLog()
+	total := maxActivitiesPerRequest + 10
+	stickyIndex := maxActivitiesPerRequest / 2 // deep in the dropped middle
+	for i := range total {
+		log.add(events.ToolActivity{
+			Tool:   fmt.Sprintf("tool-%d", i),
+			Sticky: i == stickyIndex,
+		})
+	}
+
+	activities := log.drain()
+
+	kept := 0
+	stickySurvived := false
+	for _, activity := range activities {
+		if activity.Tool == "…" {
+			continue // omission markers don't count against the cap
+		}
+		kept++
+		if activity.Tool == fmt.Sprintf("tool-%d", stickyIndex) {
+			stickySurvived = true
+		}
+	}
+	assert.True(t, stickySurvived, "sticky entry must survive the cap")
+	assert.Equal(t, maxActivitiesPerRequest, kept)
+
+	for i := 1; i < len(activities); i++ {
+		if activities[i-1].Tool == "…" || activities[i].Tool == "…" {
+			continue
+		}
+		var prev, cur int
+		fmt.Sscanf(activities[i-1].Tool, "tool-%d", &prev)
+		fmt.Sscanf(activities[i].Tool, "tool-%d", &cur)
+		assert.Less(t, prev, cur, "kept entries stay in execution order")
+	}
 }

--- a/pkg/prompts/loader.go
+++ b/pkg/prompts/loader.go
@@ -308,6 +308,7 @@ func (l *DefaultLoader) wrapHandlerWithEvents(toolName string, handler ai.Handle
 				Success:     err == nil && !result.IsError,
 				Message:     message,
 				Result:      result.Details,
+				Sticky:      result.Sticky,
 			}
 			l.Publisher.PublishSync(event.Topic(), event)
 		}

--- a/pkg/prompts/loader.go
+++ b/pkg/prompts/loader.go
@@ -249,6 +249,7 @@ func (l *DefaultLoader) wrapHandlerWithEvents(toolName string, handler ai.Handle
 			}
 			startEvent := events.ToolStartingEvent{
 				ExecutionID: executionID,
+				RequestID:   ai.RequestIDFromContext(ctx),
 				ToolName:    toolName,
 				Parameters:  filteredParams,
 			}
@@ -301,6 +302,7 @@ func (l *DefaultLoader) wrapHandlerWithEvents(toolName string, handler ai.Handle
 
 			event := events.ToolExecutedEvent{
 				ExecutionID: executionID,
+				RequestID:   ai.RequestIDFromContext(ctx),
 				ToolName:    toolName,
 				Parameters:  filteredParams, // Use filtered parameters
 				Success:     err == nil && !result.IsError,

--- a/pkg/prompts/loader_events_test.go
+++ b/pkg/prompts/loader_events_test.go
@@ -56,6 +56,55 @@ func TestWrapHandlerWithEventsPublishesTypedOutcome(t *testing.T) {
 	}
 }
 
+// Tool events must carry the chat request ID from the context so
+// consumers can correlate tool activity with the turn that caused it.
+func TestWrapHandlerWithEventsCarriesRequestID(t *testing.T) {
+	bus := events.NewEventBus()
+	var started []events.ToolStartingEvent
+	var executed []events.ToolExecutedEvent
+	events.SubscribeTo(bus, func(e events.ToolStartingEvent) {
+		started = append(started, e)
+	})
+	events.SubscribeTo(bus, func(e events.ToolExecutedEvent) {
+		executed = append(executed, e)
+	})
+
+	loader := &DefaultLoader{Publisher: bus}
+	handler := loader.wrapHandlerWithEvents("myTool", func(ctx context.Context, params map[string]any) (ai.ToolOutput, error) {
+		return ai.JSONToolOutput(map[string]any{"ok": true}), nil
+	})
+
+	ctx := ai.ContextWithRequestID(context.Background(), "req-42")
+	_, err := handler(ctx, map[string]any{})
+	require.NoError(t, err)
+
+	require.Len(t, started, 1)
+	require.Len(t, executed, 1)
+	assert.Equal(t, "req-42", started[0].RequestID)
+	assert.Equal(t, "req-42", executed[0].RequestID)
+}
+
+// Without a request ID in the context (e.g. tools run outside a chat),
+// the events carry an empty RequestID rather than a placeholder.
+func TestWrapHandlerWithEventsWithoutRequestID(t *testing.T) {
+	bus := events.NewEventBus()
+	var executed []events.ToolExecutedEvent
+	events.SubscribeTo(bus, func(e events.ToolExecutedEvent) {
+		executed = append(executed, e)
+	})
+
+	loader := &DefaultLoader{Publisher: bus}
+	handler := loader.wrapHandlerWithEvents("myTool", func(ctx context.Context, params map[string]any) (ai.ToolOutput, error) {
+		return ai.JSONToolOutput(map[string]any{"ok": true}), nil
+	})
+
+	_, err := handler(context.Background(), map[string]any{})
+	require.NoError(t, err)
+
+	require.Len(t, executed, 1)
+	assert.Empty(t, executed[0].RequestID)
+}
+
 // A panicking tool handler must fail the tool call, not crash the
 // process: in streaming mode handlers run inside producer goroutines
 // where an unrecovered panic kills the whole TUI.

--- a/pkg/prompts/loader_events_test.go
+++ b/pkg/prompts/loader_events_test.go
@@ -105,6 +105,45 @@ func TestWrapHandlerWithEventsWithoutRequestID(t *testing.T) {
 	assert.Empty(t, executed[0].RequestID)
 }
 
+// The tool's Sticky hint flows onto the event untouched: set means the
+// tool spoke ("keep this" / "don't bother"), nil means no opinion.
+// Core never second-guesses it — no heuristics.
+func TestWrapHandlerWithEventsCarriesStickyHint(t *testing.T) {
+	tests := []struct {
+		name   string
+		sticky *bool
+	}{
+		{name: "tool says keep", sticky: boolPtr(true)},
+		{name: "tool says don't bother", sticky: boolPtr(false)},
+		{name: "no opinion", sticky: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bus := events.NewEventBus()
+			var executed []events.ToolExecutedEvent
+			events.SubscribeTo(bus, func(e events.ToolExecutedEvent) {
+				executed = append(executed, e)
+			})
+
+			loader := &DefaultLoader{Publisher: bus}
+			handler := loader.wrapHandlerWithEvents("myTool", func(ctx context.Context, params map[string]any) (ai.ToolOutput, error) {
+				output := ai.JSONToolOutput(map[string]any{"ok": true})
+				output.Sticky = tt.sticky
+				return output, nil
+			})
+
+			_, err := handler(context.Background(), map[string]any{})
+			require.NoError(t, err)
+
+			require.Len(t, executed, 1)
+			assert.Equal(t, tt.sticky, executed[0].Sticky)
+		})
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
 // A panicking tool handler must fail the tool call, not crash the
 // process: in streaming mode handlers run inside producer goroutines
 // where an unrecovered panic kills the whole TUI.


### PR DESCRIPTION
## Problem

The model is procedurally blind between turns: the next turn sees prior messages, remembered files, and todos, but not what the previous turn *did* — searches run, commands and exit statuses, files edited, failures.

## What this adds

Each completed chat turn now carries a small, bounded **activity digest**, paired with the assistant message:

```
User: fix the failing openai tests
Assistant Actions:
- searchInFiles query="publishUsage" → Executed
- bash command="go test ./pkg/llm/openai" → Failed: TestResponsesUsage
- edit file="responses_turn.go" → Executed
Assistant: Fixed usage propagation and verified.
```

### The pieces

- **`RequestID` on tool events** — `ToolStartingEvent`/`ToolExecutedEvent` are stamped from the prompt context (same plumbing as #31), tying every tool call to its chat request.
- **`events.ToolActivity`** — one bounded record per call (tool, args one-liner, success, outcome). Truncation happens at creation with explicit markers; result bodies never leave the turn loop. Per-request cap drops the middle (first and last calls of a long turn carry the most signal).
- **Collector in core** — accumulates per request ID from the synchronously published events; drained exactly once at turn end (success, error, and panic paths), so buckets never leak.
- **Chat context pairing** — `ctx.Message` carries `Activities`; `AddTurn`/`RecordChatTurn` grow a *variadic* parameter so existing callers keep compiling. Rendering goes through the same formatter the budget strategy counts with, so activities are budgeted with their turn and roll out of the sliding window with it — no separate accounting.
- **`ChatResponseEvent.Activities`** — hosts get the same bundle to persist alongside the assistant message (present on failed turns too).
- **`ChatHistoryTurn.Activities`** — hosts seed restored digests through `WithChatHistory`; a restored turn renders identically to a live one.
- **`ai.ToolOutput.Sticky`** — optional tri-state retention hint (keep / don't bother / no opinion), copied verbatim onto the event. Sticky iff the tool said so; nil resolves to false. **No heuristics in core** — every retention decision traces to the tool that ran.
- **Ephemeral modes drop activities** — activity args can carry the very content the mode is hiding.

## Backward compatibility

All new fields are additive; `Sticky: nil` and empty activities reproduce today's behavior exactly. Old seeded histories work unchanged. The variadic signatures keep external `AddTurn`/`RecordChatTurn` callers compiling.

## Testing

TDD throughout — every commit is test-first. Changed packages pass with `-race`. The mock prompt runner stamps `RequestID` like the real loop, and the fixture's `StartChat` accepts chat options. (`pkg/llm/genai` `TestClient_CountTokens` fails identically on clean main — pre-existing, unrelated.)

## Out of scope (next steps)

- Per-tool `Sticky` adoption (edit/write/bash marking real mutations and their failures)
- Host side: stamping `Activities` into a message part and restoring it on instance start
