### PR TITLE
Refresh Gemini model registry; retire unavailable gemini-2.0-flash default

### DIFF
--- a/pkg/config/config_manager.go
+++ b/pkg/config/config_manager.go
@@ -122,7 +122,7 @@ func (m *DefaultManager) GetDurationWithDefault(key string, defaultValue time.Du
 
 // GetModelConfig returns the default model configuration from environment variables or defaults
 func (m *DefaultManager) GetModelConfig() ModelConfig {
-	modelName := m.GetStringWithDefault("GENIE_MODEL_NAME", "gemini-3.6-flash")
+	modelName := m.GetStringWithDefault("GENIE_MODEL_NAME", "gemini-3.7-flash")
 
 	maxTokensStr := m.GetStringWithDefault("GENIE_MAX_TOKENS", "65535")
 	maxTokens, err := strconv.ParseInt(maxTokensStr, 10, 32)

--- a/pkg/config/config_manager_test.go
+++ b/pkg/config/config_manager_test.go
@@ -47,7 +47,7 @@ func TestManager_GetModelConfig_DefaultModel(t *testing.T) {
 
 	model := (&DefaultManager{}).GetModelConfig()
 
-	assert.Equal(t, "gemini-3.6-flash", model.ModelName)
+	assert.Equal(t, "gemini-3.7-flash", model.ModelName)
 }
 
 func TestManager_RequireString(t *testing.T) {

--- a/pkg/ctx/model_registry.go
+++ b/pkg/ctx/model_registry.go
@@ -61,22 +61,23 @@ var defaultModelRegistry = map[string]ModelInfo{
 	"o4-mini":             {ContextWindow: 200000},
 
 	// Google
-	"gemini-3.6-flash":               {ContextWindow: 1048576},
-	"gemini-3.5-flash-lite":          {ContextWindow: 1048576},
-	"gemini-3.5-flash":               {ContextWindow: 1048576},
-	"gemini-3.1-flash-image-preview": {ContextWindow: 131072},
-	"gemini-3.1-flash-image":         {ContextWindow: 131072},
-	"gemini-3.1-flash-lite":          {ContextWindow: 1048576},
-	"gemini-3.1-pro-preview":         {ContextWindow: 1048576},
-	"gemini-3-pro-image-preview":     {ContextWindow: 65536},
-	"gemini-3-pro-image":             {ContextWindow: 65536},
-	"gemini-3-flash-preview":         {ContextWindow: 1048576},
-	"gemini-3-pro-preview":           {ContextWindow: 1048576},
-	"gemini-2.5-flash":               {ContextWindow: 1048576},
-	"gemini-2.5-pro":                 {ContextWindow: 1048576},
-	"gemini-2.0-flash":               {ContextWindow: 1048576},
-	"gemini-1.5-flash":               {ContextWindow: 1048576},
-	"gemini-1.5-pro":                 {ContextWindow: 2097152},
+	"gemini-3.7-flash":               {ContextWindow: 1048576, MaxOutputTokens: 65536},
+	"gemini-3.6-flash":               {ContextWindow: 1048576, MaxOutputTokens: 65536},
+	"gemini-3.5-flash-lite":          {ContextWindow: 1048576, MaxOutputTokens: 65536},
+	"gemini-3.5-flash":               {ContextWindow: 1048576, MaxOutputTokens: 65536},
+	"gemini-3.1-flash-image-preview": {ContextWindow: 65536, MaxOutputTokens: 65536},
+	"gemini-3.1-flash-image":         {ContextWindow: 65536, MaxOutputTokens: 65536},
+	"gemini-3.1-flash-lite":          {ContextWindow: 1048576, MaxOutputTokens: 65536},
+	"gemini-3.1-pro-preview":         {ContextWindow: 1048576, MaxOutputTokens: 65536},
+	"gemini-3-pro-image-preview":     {ContextWindow: 131072, MaxOutputTokens: 32768},
+	"gemini-3-pro-image":             {ContextWindow: 131072, MaxOutputTokens: 32768},
+	"gemini-3-flash-preview":         {ContextWindow: 1048576, MaxOutputTokens: 65536},
+	"gemini-3-pro-preview":           {ContextWindow: 1048576}, // stale: absent from provider catalog as of 2026-08-24
+	"gemini-2.5-flash":               {ContextWindow: 1048576, MaxOutputTokens: 65536},
+	"gemini-2.5-pro":                 {ContextWindow: 1048576, MaxOutputTokens: 65536},
+	"gemini-2.0-flash":               {ContextWindow: 1048576}, // stale: absent from provider catalog as of 2026-08-24
+	"gemini-1.5-flash":               {ContextWindow: 1048576}, // stale: absent from provider catalog as of 2026-08-24
+	"gemini-1.5-pro":                 {ContextWindow: 2097152}, // stale: absent from provider catalog as of 2026-08-24
 
 	// Local models (conservative defaults)
 	"llama":     {ContextWindow: 8192},

--- a/pkg/ctx/model_registry_test.go
+++ b/pkg/ctx/model_registry_test.go
@@ -62,11 +62,13 @@ func TestLookupContextWindow_KnownModels(t *testing.T) {
 		{model: "gpt-4o-2024-05-13", want: 128000},
 
 		// Google
+		{model: "gemini-3.7-flash", want: 1048576},
+		{model: "gemini-3.7-flash-preview-08-2026", want: 1048576},
 		{model: "gemini-3.6-flash", want: 1048576},
 		{model: "gemini-3.5-flash-lite", want: 1048576},
 		{model: "gemini-3.1-pro-preview", want: 1048576},
-		{model: "gemini-3.1-flash-image-preview", want: 131072},
-		{model: "gemini-3-pro-image", want: 65536},
+		{model: "gemini-3.1-flash-image-preview", want: 65536},
+		{model: "gemini-3-pro-image", want: 131072},
 		{model: "gemini-3-flash-preview", want: 1048576},
 		{model: "gemini-2.0-flash-latest", want: 1048576},
 	}
@@ -103,7 +105,7 @@ func TestLookupContextWindow_EmptyString(t *testing.T) {
 func TestLookupContextWindow_LongestPrefixWins(t *testing.T) {
 	assert.Equal(t, 400000, LookupContextWindow("gpt-5.4-mini"))
 	assert.Equal(t, 128000, LookupContextWindow("gpt-5.3-chat-latest"))
-	assert.Equal(t, 131072, LookupContextWindow("gemini-3.1-flash-image-preview"))
+	assert.Equal(t, 65536, LookupContextWindow("gemini-3.1-flash-image-preview"))
 }
 
 func TestLookupContextWindow_DoesNotMatchUnrelatedPrefix(t *testing.T) {

--- a/pkg/llm/genai/client.go
+++ b/pkg/llm/genai/client.go
@@ -531,7 +531,7 @@ func (g *Client) countTokensWithPrompt(ctx context.Context, p ai.Prompt) (*ai.To
 	// Use model name from prompt, or fallback to default
 	modelName := p.ModelName
 	if modelName == "" {
-		modelName = "gemini-2.0-flash" // Default model
+		modelName = "gemini-3.7-flash" // Default model
 	}
 	// Count tokens using the Models.CountTokens method
 	countResp, err := g.Client.Models.CountTokens(ctx, modelName, contents, nil)

--- a/pkg/llm/genai/count_tokens_test.go
+++ b/pkg/llm/genai/count_tokens_test.go
@@ -19,7 +19,7 @@ func TestClient_CountTokens(t *testing.T) {
 	// Test basic token counting
 	prompt := ai.Prompt{
 		Text:      "The quick brown fox jumps over the lazy dog.",
-		ModelName: "gemini-2.0-flash",
+		ModelName: "gemini-3.7-flash",
 	}
 
 	ctx := context.Background()
@@ -48,7 +48,7 @@ func TestClient_CountTokens_WithInstruction(t *testing.T) {
 	prompt := ai.Prompt{
 		Instruction: "You are a helpful assistant.",
 		Text:        "Hello, how are you?",
-		ModelName:   "gemini-2.0-flash",
+		ModelName:   "gemini-3.7-flash",
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
## Why now

`pkg/llm/genai` tests fail on main: the live CountTokens tests and the client fallback reference `gemini-2.0-flash`, which Google no longer serves. Meanwhile `gemini-3.7-flash` shipped and had no registry entry.

## Provenance

All values below from `GET https://generativelanguage.googleapis.com/v1beta/models` fetched during this run (2026-08-24). No value was written from memory.

| Model | Field | Old | New | Source |
|---|---|---|---|---|
| gemini-3.7-flash | ContextWindow | — | 1048576 | v1beta/models (this run) |
| gemini-3.7-flash | MaxOutputTokens | — | 65536 | v1beta/models (this run) |
| gemini-3.6-flash, 3.5-flash, 3.5-flash-lite, 3.1-flash-lite, 3.1-pro-preview, 3-flash-preview, 2.5-flash, 2.5-pro | MaxOutputTokens | 0 (unverified) | 65536 | v1beta/models (this run) |
| gemini-3.1-flash-image(-preview) | ContextWindow | 131072 | 65536 | v1beta/models (this run) |
| gemini-3.1-flash-image(-preview) | MaxOutputTokens | 0 | 65536 | v1beta/models (this run) |
| gemini-3-pro-image(-preview) | ContextWindow | 65536 | 131072 | v1beta/models (this run) |
| gemini-3-pro-image(-preview) | MaxOutputTokens | 0 | 32768 | v1beta/models (this run) |

`InputModalities` left nil throughout — no complete capability object was examined this run.

## Stale entries (kept, per policy — deletion is a reviewer decision)

Absent from the provider catalog as of 2026-08-24, now marked with dated comments:

- `gemini-3-pro-preview`
- `gemini-2.0-flash`
- `gemini-1.5-flash`, `gemini-1.5-pro`

## Default model bump (second commit)

`gemini-2.0-flash` → `gemini-3.7-flash` in the genai client fallback (`client.go`), the `GENIE_MODEL_NAME` config default (was `gemini-3.6-flash`), and the live CountTokens tests. This is what makes `go test ./pkg/llm/genai` pass again.

## Skipped providers

Anthropic/OpenAI/local untouched — scope was the Gemini failure. Registry-walk and lookup tests pass; lookup tests extended for the 3.7 family.