### PR TITLE
Logging: slog-native, host-injectable, context-correlated — and no user content

### DIFF
--- a/cmd/cli/ask.go
+++ b/cmd/cli/ask.go
@@ -139,7 +139,7 @@ func runAskCommandWithSession(cmd *cobra.Command, args []string, g genie.Genie, 
 	defer logging.SetGlobalLogger(originalLogger)
 
 	logger := logging.GetGlobalLogger()
-	logger.Debug("starting ask command", "accept-all", acceptAll, "debug", debug, "verbose", verbose, "message", message)
+	logger.Debug("starting ask command", "accept-all", acceptAll, "debug", debug, "verbose", verbose)
 
 	// Create channel to signal completion
 	done := make(chan error, 1)

--- a/cmd/tui/controllers/chat.go
+++ b/cmd/tui/controllers/chat.go
@@ -241,7 +241,7 @@ func NewChatController(
 	// Subscribe to user input events (only text now - commands handled by CommandHandler)
 	commandEventBus.Subscribe("user.input.text", func(event interface{}) {
 		if message, ok := event.(string); ok {
-			c.logger().Debug("Processing user input", "message", message)
+			c.logger().Debug("Processing user input", "length", len(message))
 			c.handleChatMessage(message)
 			c.renderMessages()
 		}

--- a/cmd/tui/controllers/tool_confirmation_controller.go
+++ b/cmd/tui/controllers/tool_confirmation_controller.go
@@ -110,7 +110,7 @@ func (tc *ToolConfirmationController) HandleToolConfirmationRequest(event core_e
 
 	title := fmt.Sprintf("Tool: %s", event.ToolName)
 	message := event.Message
-	tc.logger().Debug("Showing confirmation message in viewer", "message", message, "tool", event.ToolName)
+	tc.logger().Debug("Showing confirmation message in viewer", "tool", event.ToolName)
 
 	// All gocui state modifications must run on the main loop
 	tc.gui.GetGui().Update(func(g *gocui.Gui) error {

--- a/pkg/ctx/chat_context_part_provider.go
+++ b/pkg/ctx/chat_context_part_provider.go
@@ -129,7 +129,7 @@ func (m *InMemoryChatContextPartProvider) GetPart(ctx context.Context) (ContextP
 	if strategy != nil && tokenBudget > 0 {
 		kept, tokensUsed := strategy.ApplyToCollection(messages, tokenBudget, formatMessageForContext)
 		if dropped := len(messages) - len(kept); dropped > 0 {
-			slog.Info("chat history pruned",
+			slog.InfoContext(ctx, "chat history pruned",
 				"strategy", strategy.Name(),
 				"total", len(messages),
 				"kept", len(kept),

--- a/pkg/ctx/file_context_part_provider.go
+++ b/pkg/ctx/file_context_part_provider.go
@@ -176,7 +176,7 @@ func (p *FileContextPartsProvider) GetPart(ctx context.Context) (ContextPart, er
 	}
 
 	if evicted > 0 || trimmed > 0 {
-		slog.Info("file context pruned",
+		slog.InfoContext(ctx, "file context pruned",
 			"lru_strategy", lruName,
 			"soft_trim_strategy", softTrimName,
 			"total", totalBefore,

--- a/pkg/genie/core.go
+++ b/pkg/genie/core.go
@@ -321,7 +321,7 @@ func (g *core) Start(workingDir *string, persona *string, opts ...StartOption) (
 	// failure at turn time (permissions, a stale mount) cannot silently
 	// strip agent-wide rules from prompts mid-session.
 	if _, err := g.contextMgr.GetContextParts(startCtx); err != nil {
-		slog.Warn("context warm-up at start failed; continuing with cold caches", "error", err)
+		slog.WarnContext(startCtx, "context warm-up at start failed; continuing with cold caches", "error", err)
 	}
 
 	// Return session directly - session.Session implements genie.Session
@@ -361,7 +361,7 @@ func (g *core) initContextBudget(startCtx context.Context) {
 		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 && parsed <= 1.0 {
 			ratio = parsed
 		} else {
-			slog.Warn("Invalid GENIE_CONTEXT_BUDGET_RATIO ignored",
+			slog.WarnContext(startCtx, "Invalid GENIE_CONTEXT_BUDGET_RATIO ignored",
 				"value", raw,
 				"fallback_ratio", ratio,
 			)
@@ -371,7 +371,7 @@ func (g *core) initContextBudget(startCtx context.Context) {
 	budget := ctx.ContextBudget(explicitBudget, modelName, ratio)
 	g.contextMgr.SetContextBudget(budget)
 
-	slog.Info("Context budget initialized",
+	slog.InfoContext(startCtx, "Context budget initialized",
 		"explicit_budget", explicitBudget,
 		"model", modelName,
 		"ratio", ratio,
@@ -747,7 +747,7 @@ func (g *core) preparePromptData(ctx context.Context, message string) map[string
 		// If context retrieval fails, continue with empty context but
 		// tell the user: the model is silently losing all project/file/
 		// chat context for this turn, which otherwise looks like amnesia.
-		slog.Error("Failed to retrieve context parts, continuing with empty context", "error", err)
+		slog.ErrorContext(ctx, "Failed to retrieve context parts, continuing with empty context", "error", err)
 		if g.eventBus != nil {
 			notification := events.NotificationEvent{
 				Message: fmt.Sprintf("Warning: failed to assemble conversation context; replying without project/chat context (%v)", err),

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -228,14 +228,29 @@ func (l *slogLogger) SetLevel(level slog.Level) {
 
 	// Replace the logger with a new one with the updated level
 	l.logger = slog.New(handler)
+	// A rebuilt handler leaves any slog.SetDefault snapshot stale —
+	// re-sync when this logger is the global one.
+	if globalLogger == Logger(l) {
+		syncSlogDefault(l)
+	}
 }
 
 // Global logger instance
 var globalLogger Logger = NewDefaultLogger()
 
-// SetGlobalLogger sets the global logger instance
+// SetGlobalLogger sets the global logger instance. The stdlib slog
+// default logger is pointed at the same destination, so direct slog
+// calls anywhere in the codebase follow the configured output instead
+// of leaking to stderr (and onto the terminal after the TUI exits).
 func SetGlobalLogger(logger Logger) {
 	globalLogger = logger
+	syncSlogDefault(logger)
+}
+
+func syncSlogDefault(logger Logger) {
+	if sl, ok := logger.(*slogLogger); ok {
+		slog.SetDefault(sl.logger)
+	}
 }
 
 // GetGlobalLogger returns the global logger instance

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -9,12 +9,19 @@ import (
 	"strings"
 )
 
-// Logger interface for dependency injection and testing
+// Logger interface for dependency injection and testing.
+// The *Context variants hand the caller's context to the handler — an
+// OTel bridge handler reads the active span from it for correlation, so
+// prefer them wherever a context is in scope.
 type Logger interface {
 	Debug(msg string, args ...any)
 	Info(msg string, args ...any)
 	Warn(msg string, args ...any)
 	Error(msg string, args ...any)
+	DebugContext(ctx context.Context, msg string, args ...any)
+	InfoContext(ctx context.Context, msg string, args ...any)
+	WarnContext(ctx context.Context, msg string, args ...any)
+	ErrorContext(ctx context.Context, msg string, args ...any)
 	With(args ...any) Logger
 	WithGroup(name string) Logger
 	SetLevel(level slog.Level) // Add method for dynamic level changes
@@ -26,6 +33,11 @@ type Config struct {
 	Format  Format
 	Output  io.Writer
 	AddTime bool
+	// Handler, when set, is used as-is and the other fields are ignored:
+	// the host owns output, format, and filtering. This is how an
+	// embedding host (e.g. Mutiro) plugs an OTel log bridge under all of
+	// genie's logging, direct slog calls included.
+	Handler slog.Handler
 }
 
 // Format represents the output format
@@ -44,6 +56,12 @@ type slogLogger struct {
 
 // NewLogger creates a new logger with the given configuration
 func NewLogger(config Config) Logger {
+	if config.Handler != nil {
+		return &slogLogger{
+			logger: slog.New(config.Handler),
+			config: config,
+		}
+	}
 	if config.Output == nil {
 		config.Output = os.Stderr
 	}
@@ -183,6 +201,22 @@ func (l *slogLogger) Error(msg string, args ...any) {
 	l.logger.Error(msg, args...)
 }
 
+func (l *slogLogger) DebugContext(ctx context.Context, msg string, args ...any) {
+	l.logger.DebugContext(ctx, msg, args...)
+}
+
+func (l *slogLogger) InfoContext(ctx context.Context, msg string, args ...any) {
+	l.logger.InfoContext(ctx, msg, args...)
+}
+
+func (l *slogLogger) WarnContext(ctx context.Context, msg string, args ...any) {
+	l.logger.WarnContext(ctx, msg, args...)
+}
+
+func (l *slogLogger) ErrorContext(ctx context.Context, msg string, args ...any) {
+	l.logger.ErrorContext(ctx, msg, args...)
+}
+
 // With returns a logger with additional attributes
 func (l *slogLogger) With(args ...any) Logger {
 	return &slogLogger{
@@ -201,6 +235,11 @@ func (l *slogLogger) WithGroup(name string) Logger {
 
 // SetLevel updates the logger's level dynamically
 func (l *slogLogger) SetLevel(level slog.Level) {
+	// A host-injected handler owns its own filtering — keep it.
+	if l.config.Handler != nil {
+		return
+	}
+
 	// Update the config
 	l.config.Level = level
 

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -394,3 +394,83 @@ func TestSetLevelKeepsSlogDefaultInSync(t *testing.T) {
 		t.Fatalf("slog default went stale after SetLevel, got: %q", buf.String())
 	}
 }
+
+// captureHandler records what it handles, including the context — the
+// contract an OTel bridge handler relies on for trace correlation.
+type captureHandler struct {
+	records []slog.Record
+	ctxs    []context.Context
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *captureHandler) Handle(ctx context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	h.ctxs = append(h.ctxs, ctx)
+	return nil
+}
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
+
+type testCtxKey struct{}
+
+// Hosts (e.g. Mutiro with an OTel log bridge) inject their own handler;
+// genie must route records through it instead of building its own.
+func TestNewLoggerWithInjectedHandler(t *testing.T) {
+	capture := &captureHandler{}
+	logger := NewLogger(Config{Handler: capture})
+
+	logger.Info("through the host handler")
+
+	if len(capture.records) != 1 || capture.records[0].Message != "through the host handler" {
+		t.Fatalf("record did not reach injected handler: %+v", capture.records)
+	}
+}
+
+// Context-aware calls must hand the caller's context to the handler —
+// that is where an OTel bridge reads the active span for correlation.
+func TestContextMethodsCarryContextToHandler(t *testing.T) {
+	capture := &captureHandler{}
+	logger := NewLogger(Config{Handler: capture})
+
+	ctx := context.WithValue(context.Background(), testCtxKey{}, "trace-me")
+	logger.InfoContext(ctx, "correlated line")
+
+	if len(capture.ctxs) != 1 {
+		t.Fatalf("expected one handled record, got %d", len(capture.ctxs))
+	}
+	if capture.ctxs[0].Value(testCtxKey{}) != "trace-me" {
+		t.Fatal("handler did not receive the caller's context")
+	}
+}
+
+func TestSetGlobalLoggerBridgesInjectedHandler(t *testing.T) {
+	prevGlobal := GetGlobalLogger()
+	prevSlog := slog.Default()
+	t.Cleanup(func() {
+		SetGlobalLogger(prevGlobal)
+		slog.SetDefault(prevSlog)
+	})
+
+	capture := &captureHandler{}
+	SetGlobalLogger(NewLogger(Config{Handler: capture}))
+
+	slog.Info("stray slog line")
+
+	if len(capture.records) != 1 || capture.records[0].Message != "stray slog line" {
+		t.Fatalf("stray slog call did not reach injected handler: %+v", capture.records)
+	}
+}
+
+// SetLevel must not discard a host-injected handler: the host owns
+// filtering, so the handler stays and keeps receiving records.
+func TestSetLevelKeepsInjectedHandler(t *testing.T) {
+	capture := &captureHandler{}
+	logger := NewLogger(Config{Handler: capture})
+
+	logger.SetLevel(slog.LevelDebug)
+	logger.Debug("still through the host handler")
+
+	if len(capture.records) != 1 {
+		t.Fatalf("injected handler lost after SetLevel: %+v", capture.records)
+	}
+}

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -335,3 +335,62 @@ func TestLogErrorWithOperation(t *testing.T) {
 		t.Errorf("LogErrorWithOperation() should contain operation field, got: %s", output)
 	}
 }
+
+// Direct slog calls (slog.Info etc.) must follow the global logger's
+// destination — stray stdlib logging must never leak to the terminal
+// when the host routed genie logs elsewhere (e.g. the TUI's log file).
+func TestSetGlobalLoggerRoutesSlogDefault(t *testing.T) {
+	prevGlobal := GetGlobalLogger()
+	prevSlog := slog.Default()
+	t.Cleanup(func() {
+		SetGlobalLogger(prevGlobal)
+		slog.SetDefault(prevSlog)
+	})
+
+	var buf bytes.Buffer
+	SetGlobalLogger(NewLogger(Config{Level: slog.LevelInfo, Format: FormatText, Output: &buf}))
+
+	slog.Info("via default slog")
+
+	if !strings.Contains(buf.String(), "via default slog") {
+		t.Fatalf("slog default output not routed to global logger, got: %q", buf.String())
+	}
+}
+
+func TestSetGlobalLoggerSlogDefaultRespectsLevel(t *testing.T) {
+	prevGlobal := GetGlobalLogger()
+	prevSlog := slog.Default()
+	t.Cleanup(func() {
+		SetGlobalLogger(prevGlobal)
+		slog.SetDefault(prevSlog)
+	})
+
+	var buf bytes.Buffer
+	SetGlobalLogger(NewLogger(Config{Level: slog.LevelInfo, Format: FormatText, Output: &buf}))
+
+	slog.Debug("filtered debug line")
+
+	if strings.Contains(buf.String(), "filtered debug line") {
+		t.Fatalf("debug line should be filtered at info level, got: %q", buf.String())
+	}
+}
+
+func TestSetLevelKeepsSlogDefaultInSync(t *testing.T) {
+	prevGlobal := GetGlobalLogger()
+	prevSlog := slog.Default()
+	t.Cleanup(func() {
+		SetGlobalLogger(prevGlobal)
+		slog.SetDefault(prevSlog)
+	})
+
+	var buf bytes.Buffer
+	logger := NewLogger(Config{Level: slog.LevelInfo, Format: FormatText, Output: &buf})
+	SetGlobalLogger(logger)
+
+	logger.SetLevel(slog.LevelDebug)
+	slog.Debug("debug after level change")
+
+	if !strings.Contains(buf.String(), "debug after level change") {
+		t.Fatalf("slog default went stale after SetLevel, got: %q", buf.String())
+	}
+}

--- a/pkg/tools/skill.go
+++ b/pkg/tools/skill.go
@@ -50,9 +50,9 @@ func NewSkillTool(skillManager skills.SkillManager, publisher events.Publisher) 
 func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse, error) {
 	// Case 1: Clear active skill (skill="" and file="")
 	if params.Skill == "" && params.File == "" {
-		slog.Debug("Clearing active skill", "params", params)
+		slog.DebugContext(ctx, "Clearing active skill")
 		if err := t.skillManager.ClearActiveSkill(ctx); err != nil {
-			slog.Error("Failed to clear active skill", "error", err)
+			slog.ErrorContext(ctx, "Failed to clear active skill", "error", err)
 			return SkillResponse{
 				Status:  "error",
 				Message: fmt.Sprintf("Failed to clear active skill: %v", err),
@@ -64,7 +64,7 @@ func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse,
 			t.publisher.Publish("skill.cleared", events.SkillClearedEvent{})
 		}
 
-		slog.Info("Skill cleared successfully")
+		slog.InfoContext(ctx, "Skill cleared successfully")
 		return SkillResponse{
 			Status:  "completed",
 			Message: "Skill completed and context cleared",
@@ -73,9 +73,9 @@ func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse,
 
 	// Case 2: Load file without activating new skill (skill="" and file!="")
 	if params.Skill == "" && params.File != "" {
-		slog.Debug("Loading file into active skill", "file", params.File)
+		slog.DebugContext(ctx, "Loading file into active skill", "file", params.File)
 		if err := t.skillManager.LoadSkillFile(ctx, params.File); err != nil {
-			slog.Error("Failed to load file into active skill", "file", params.File, "error", err)
+			slog.ErrorContext(ctx, "Failed to load file into active skill", "file", params.File, "error", err)
 
 			// Check if there's an active skill to provide context
 			activeSkill, _ := t.skillManager.GetActiveSkill(ctx)
@@ -90,7 +90,7 @@ func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse,
 			}, err
 		}
 
-		slog.Info("File loaded successfully into skill context", "file", params.File)
+		slog.InfoContext(ctx, "File loaded successfully into skill context", "file", params.File)
 		return SkillResponse{
 			Status:  "loaded",
 			Message: fmt.Sprintf("File '%s' loaded successfully into skill context", params.File),
@@ -98,13 +98,13 @@ func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse,
 	}
 
 	// Case 3 & 4: Load and activate skill (skill!="")
-	slog.Debug("Loading skill", "skill", params.Skill, "file", params.File, "task", params.Task)
+	slog.DebugContext(ctx, "Loading skill", "skill", params.Skill, "file", params.File)
 	skill, err := t.skillManager.LoadSkill(ctx, params.Skill)
 	if err != nil {
 		// Check if error message contains "not found"
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "not found") {
-			slog.Error("Skill not found", "skill", params.Skill, "error", err)
+			slog.ErrorContext(ctx, "Skill not found", "skill", params.Skill, "error", err)
 
 			// Get available skills to provide helpful suggestions
 			availableSkills, listErr := t.skillManager.ListSkills(ctx)
@@ -127,7 +127,7 @@ func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse,
 				Message:   helpMsg,
 			}, err
 		}
-		slog.Error("Failed to load skill", "skill", params.Skill, "error", err)
+		slog.ErrorContext(ctx, "Failed to load skill", "skill", params.Skill, "error", err)
 		return SkillResponse{
 			Status:    "error",
 			SkillName: params.Skill,
@@ -137,7 +137,7 @@ func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse,
 
 	// Set as active skill
 	if err := t.skillManager.SetActiveSkill(ctx, skill); err != nil {
-		slog.Error("Failed to activate skill", "skill", params.Skill, "error", err)
+		slog.ErrorContext(ctx, "Failed to activate skill", "skill", params.Skill, "error", err)
 		return SkillResponse{
 			Status:    "error",
 			SkillName: params.Skill,
@@ -145,7 +145,7 @@ func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse,
 		}, err
 	}
 
-	slog.Info("Skill activated successfully", "skill", params.Skill, "base_dir", skill.BaseDir)
+	slog.InfoContext(ctx, "Skill activated successfully", "skill", params.Skill, "base_dir", skill.BaseDir)
 
 	// Publish skill invoked event
 	if t.publisher != nil {
@@ -156,9 +156,9 @@ func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse,
 
 	// Case 4: If file was also specified, load it now that skill is active
 	if params.File != "" {
-		slog.Debug("Loading additional file for activated skill", "skill", params.Skill, "file", params.File)
+		slog.DebugContext(ctx, "Loading additional file for activated skill", "skill", params.Skill, "file", params.File)
 		if err := t.skillManager.LoadSkillFile(ctx, params.File); err != nil {
-			slog.Error("Skill activated but file load failed", "skill", params.Skill, "file", params.File, "error", err)
+			slog.ErrorContext(ctx, "Skill activated but file load failed", "skill", params.Skill, "file", params.File, "error", err)
 			return SkillResponse{
 				Status:    "error",
 				SkillName: params.Skill,
@@ -166,7 +166,7 @@ func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse,
 			}, err
 		}
 
-		slog.Info("Skill and file loaded successfully", "skill", params.Skill, "file", params.File)
+		slog.InfoContext(ctx, "Skill and file loaded successfully", "skill", params.Skill, "file", params.File)
 
 		response := SkillResponse{
 			Status:      "loaded",
@@ -180,7 +180,7 @@ func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse,
 		if params.ListFiles {
 			files, err := t.listSkillFiles(skill.BaseDir)
 			if err != nil {
-				slog.Warn("Failed to list skill files", "skill", params.Skill, "error", err)
+				slog.WarnContext(ctx, "Failed to list skill files", "skill", params.Skill, "error", err)
 				response.Message += fmt.Sprintf("\n\nWarning: Could not list skill files: %v", err)
 			} else {
 				response.Files = files
@@ -192,7 +192,7 @@ func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse,
 	}
 
 	// Case 3: Skill loaded without additional file
-	slog.Info("Skill loaded successfully", "skill", params.Skill)
+	slog.InfoContext(ctx, "Skill loaded successfully", "skill", params.Skill)
 
 	response := SkillResponse{
 		Status:      "loaded",
@@ -206,7 +206,7 @@ func (t *SkillTool) Run(ctx context.Context, params SkillParams) (SkillResponse,
 	if params.ListFiles {
 		files, err := t.listSkillFiles(skill.BaseDir)
 		if err != nil {
-			slog.Warn("Failed to list skill files", "skill", params.Skill, "error", err)
+			slog.WarnContext(ctx, "Failed to list skill files", "skill", params.Skill, "error", err)
 			response.Message += fmt.Sprintf("\n\nWarning: Could not list skill files: %v", err)
 		} else {
 			response.Files = files
@@ -335,11 +335,11 @@ func (t *SkillTool) Handler() ai.HandlerFunc {
 		responseMap := make(map[string]any)
 		jsonResp, marshalErr := json.Marshal(resp)
 		if marshalErr != nil {
-			slog.Error("Failed to marshal skill response", "error", marshalErr)
+			slog.ErrorContext(ctx, "Failed to marshal skill response", "error", marshalErr)
 			return ai.ToolOutput{}, fmt.Errorf("failed to marshal tool response: %w", marshalErr)
 		}
 		if unmarshalErr := json.Unmarshal(jsonResp, &responseMap); unmarshalErr != nil {
-			slog.Error("Failed to unmarshal skill response to map", "error", unmarshalErr)
+			slog.ErrorContext(ctx, "Failed to unmarshal skill response to map", "error", unmarshalErr)
 			return ai.ToolOutput{}, fmt.Errorf("failed to unmarshal tool response to map: %w", unmarshalErr)
 		}
 
@@ -349,7 +349,7 @@ func (t *SkillTool) Handler() ai.HandlerFunc {
 			// These should be communicated to the LLM, not terminate the generation
 			if resp.Status == "error" {
 				// Log the error but return the response to LLM with nil error
-				slog.Warn("Skill operation failed", "status", resp.Status, "message", resp.Message, "error", err)
+				slog.WarnContext(ctx, "Skill operation failed", "status", resp.Status, "message", resp.Message, "error", err)
 
 				// Publish error event for UI
 				if t.publisher != nil {
@@ -366,7 +366,7 @@ func (t *SkillTool) Handler() ai.HandlerFunc {
 			}
 
 			// For unexpected errors, log and propagate
-			slog.Error("Unexpected skill tool error", "error", err)
+			slog.ErrorContext(ctx, "Unexpected skill tool error", "error", err)
 			return ai.ToolOutput{}, err
 		}
 


### PR DESCRIPTION
Three layered changes that make genie's logging compose with a host's OTel pipeline (the Mutiro OTel work) and keep user content out of telemetry.

## 1. Stdlib slog default routed through the global logger

Direct `slog.Info/Warn/Debug` calls (e.g. "Context budget initialized" in core.go, "chat history pruned" in the chat provider) wrote to stderr through Go's default handler, bypassing genie's logging and surfacing on the terminal after the TUI exits. `SetGlobalLogger` now points `slog.SetDefault` at the same handler; `SetLevel` re-syncs when it rebuilds the handler.

## 2. Host-injectable handler + context-aware calls

- `logging.Config.Handler` lets an embedding host supply its own `slog.Handler` — an OTel log bridge (`otelslog`), a test capture — and everything routes through it, stray slog calls included. `SetLevel` defers filtering to a host handler.
- The `Logger` interface gains `DebugContext/InfoContext/WarnContext/ErrorContext`, and every direct slog call with a context in scope now uses the `*Context` variant (core request path, ctx providers, the skill tool). That context is where an OTel bridge reads the active span — genie log records correlate to the turn's trace with zero OTel dependency inside genie.
- Interface note: `slogLogger` is the only implementer in-tree; external implementers of `logging.Logger` need the four new methods.

## 3. No user content in logs

Audited all 49 log call sites. User-authored content removed from:

- skill tool: raw `params` and `task` text dropped from debug logs
- `ask` command: user message dropped from the startup debug line
- TUI: confirmation-viewer and input debug lines log tool name / message length instead of the body

CLI verbose narration and TUI rendering are unchanged — display is not telemetry. The llm clients were already clean (model names only).

## Follow-up for Mutiro

Inject the OTel log bridge: `logging.SetGlobalLogger(logging.NewLogger(logging.Config{Handler: otelslogHandler}))` — logs, traces, and session entries then join on the same trace/request IDs.