### PR TITLE
CLI: default logger to warn level so startup info stays off the terminal

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/kcaldas/genie/cmd/bootstrap"
 	"github.com/kcaldas/genie/cmd/tui"
@@ -39,7 +40,14 @@ var RootCmd = &cobra.Command{
 		} else if verbose {
 			logger = logging.NewVerboseLogger()
 		} else {
-			logger = logging.NewDefaultLogger()
+			// Warnings and errors only: Genie starts (and logs
+			// startup info like the context budget) before
+			// subcommands install their own loggers, so the default
+			// must keep info-level chatter off the terminal.
+			logger = logging.NewLogger(logging.Config{
+				Level:  slog.LevelWarn,
+				Format: logging.FormatText,
+			})
 		}
 		logging.SetGlobalLogger(logger)
 


### PR DESCRIPTION
Follow-up to #34's verification. The root command installs the default (info-level) logger and then starts Genie — before `ask` (or the TUI) installs its own logger. So startup lines like "Context budget initialized" printed to the terminal even in non-verbose runs; #34 routed them through the bridge but the active level at startup was still Info.

Non-verbose CLI default is now warn-level, matching `ask`'s stated "only warnings and errors for clean output" intent. `--verbose` and `--quiet` unchanged. Verified: `genie ask` output is now just the response.